### PR TITLE
[Dist/Tizen] Add RPM spec and manifest files for RPM packaging 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,18 +25,17 @@ ELSE(GST_INSTALL_DIR)
 ENDIF(GST_INSTALL_DIR)
 
 FIND_PACKAGE(PkgConfig REQUIRED)
-SET(PKG_MODULES
-    gstreamer-1.0
-    gstreamer-base-1.0
-    gstreamer-controller-1.0
-    gstreamer-video-1.0
-    gstreamer-audio-1.0
-    nnstreamer
+SET(PKG_COMMON_MODULES
     glib-2.0
+    gstreamer-1.0
+    nnstreamer
 )
-PKG_CHECK_MODULES(pkgs REQUIRED ${PKG_MODULES})
+PKG_CHECK_MODULES(PKGS_COMMON REQUIRED ${PKG_COMMON_MODULES})
 
-INCLUDE_DIRECTORIES(./common/include)
+INCLUDE_DIRECTORIES(
+	./common/include
+	${PKGS_COMMON_INCLUDE_DIRS}
+	)
 
 SET(c_flags -Wall -Werror -fPIC -g -std=c89)
 SET(cxx_flags -Wall -Werror -fPIC -g -std=c++11)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -132,9 +132,9 @@ generate_messages(
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
     INCLUDE_DIRS include
-    #  LIBRARIES my_first_ros_pkg
+    LIBRARIES nns_ros_bridge
     CATKIN_DEPENDS roscpp std_msgs message_runtime
-    #  DEPENDS system_lib
+    DEPENDS ${PKGS_COMMON}
     )
 
 SET(CXX_SRC_FILES_NNS_ROS_BRIDGE
@@ -149,7 +149,6 @@ SET(CXX_SRC_FILES_NNS_ROS_BRIDGE
 ## Your package locations should be listed before other locations
 INCLUDE_DIRECTORIES(
     ${catkin_INCLUDE_DIRS}
-    ${pkgs_INCLUDE_DIRS}
     )
 
 ## Declare a C++ library
@@ -182,7 +181,7 @@ add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EX
 ## Specify libraries to link a library or executable target against
 TARGET_LINK_LIBRARIES(nns_ros_bridge
     ${catkin_LIBRARIES}
-    ${pkgs_LIBRARIES}
+    ${PKGS_COMMON_LIBRARIES}
     )
 
 #############
@@ -234,7 +233,7 @@ TARGET_LINK_LIBRARIES(nns_ros_bridge
 # catkin_add_nosetests(test)
 
 INSTALL(TARGETS nns_ros_bridge
-	RUNTIME DESTINATION ${EXEC_PREFIX}
-	LIBRARY DESTINATION ${LIB_INSTALL_DIR}
-	ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )

--- a/common/include/nns_ros_bridge.h
+++ b/common/include/nns_ros_bridge.h
@@ -26,7 +26,8 @@
 #ifndef _NNS_ROS_BRIDGE_H_
 #define _NNS_ROS_BRIDGE_H_
 #include <glib-2.0/glib.h>
-#include <nnstreamer/tensor_common.h>
+#include <nnstreamer/tensor_typedef.h>
+#include <nnstreamer/nnstreamer_plugin_api.h>
 #ifdef __cplusplus
 #include <ros/ros.h>
 #include <std_msgs/MultiArrayLayout.h>

--- a/gst/tensor_ros_sink/CMakeLists.txt
+++ b/gst/tensor_ros_sink/CMakeLists.txt
@@ -2,13 +2,8 @@ ADD_LIBRARY(tensor_ros_sink tensor_ros_sink.c)
 ADD_DEPENDENCIES(tensor_ros_sink nns_ros_bridge)
 TARGET_LINK_LIBRARIES(tensor_ros_sink
     nns_ros_bridge
-    nnstreamer
-    ${pkgs_LIBRARIES}
+    ${PKGS_COMMON_LIBRARIES}
     )
-
-INCLUDE_DIRECTORIES(
-    ${pkgs_INCLUDE_DIRS}
-)
 
 INSTALL(TARGETS tensor_ros_sink
 	RUNTIME DESTINATION ${EXEC_PREFIX}

--- a/gst/tensor_ros_sink/tensor_ros_sink.c
+++ b/gst/tensor_ros_sink/tensor_ros_sink.c
@@ -33,7 +33,8 @@
 #endif
 
 #include <nns_ros_bridge.h>
-#include <nnstreamer/tensor_common.h>
+#include <nnstreamer/tensor_typedef.h>
+#include <nnstreamer/nnstreamer_plugin_api.h>
 
 #include "tensor_ros_sink.h"
 

--- a/gst/tensor_ros_sink/tensor_ros_sink.h
+++ b/gst/tensor_ros_sink/tensor_ros_sink.h
@@ -27,9 +27,9 @@
 #ifndef __GST_TENSOR_ROS_SINK_H__
 #define __GST_TENSOR_ROS_SINK_H__
 
-#include <gst/gst.h>
 #include <gst/base/gstbasesink.h>
-#include <nnstreamer/tensor_common.h>
+#include <nnstreamer/tensor_typedef.h>
+#include <nnstreamer/nnstreamer_plugin_api.h>
 
 G_BEGIN_DECLS
 

--- a/packaging/nnstreamer-ros.manifest
+++ b/packaging/nnstreamer-ros.manifest
@@ -1,0 +1,5 @@
+<manifest>
+ <request>
+    <domain name="_"/>
+ </request>
+</manifest>

--- a/packaging/nnstreamer-ros.spec
+++ b/packaging/nnstreamer-ros.spec
@@ -1,0 +1,61 @@
+Name:		nnstreamer-ros
+Summary:	nnstreamer extension plugins for ROS support
+Version:	0.0.1
+Release:	0
+Group:		Applications/Multimedia
+Packager:	Wook Song <wook16.song@samsung.com>
+License:	LGPL-2.1
+Source0:	nnstreamer-ros-%{version}.tar.gz
+Source1001:	nnstreamer-ros.manifest
+
+BuildRequires:	cmake
+# boost
+BuildRequires:  pkg-config
+BuildRequires:  pkgconfig(boost)
+# gstremaer
+BuildRequires:	pkgconfig(gstreamer-1.0)
+BuildRequires:	pkgconfig(gstreamer-base-1.0)
+BuildRequires:	pkgconfig(gstreamer-audio-1.0)
+BuildRequires:	pkgconfig(gstreamer-video-1.0)
+# nnstreamer
+BuildRequires:  pkgconfig(nnstreamer)
+# ROS
+BuildRequires:  ros-kinetic-catkin
+BuildRequires:	ros-kinetic-genmsg
+BuildRequires:	ros-kinetic-message-generation
+BuildRequires:	ros-kinetic-roscpp
+
+%description
+A set of NNStreamer extension plugins for ROS support
+
+%prep
+%setup -q
+cp %{SOURCE1001} .
+
+%build
+%{__ros_setup}
+%__ros_build_pkg "-DLIB_INSTALL_DIR=%{_libdir}"
+
+%install
+%{__ros_setup}
+%{__ros_install}
+
+%files
+%manifest nnstreamer-ros.manifest
+%defattr(-,root,root,-)
+%license LICENSE
+%{_libdir}/gstreamer-1.0/libtensor_ros_sink.so
+%{__ros_install_path}/lib/libnns_ros_bridge.so
+%{__ros_install_path}/lib/python2.7/site-packages/nns_ros_bridge/*
+%{__ros_install_path}/share/nns_ros_bridge/cmake/*
+%{__ros_install_path}/share/nns_ros_bridge/msg/*
+%{__ros_install_path}/share/nns_ros_bridge/package.xml
+%{__ros_install_path}/include/nns_ros_bridge/tensors.h
+%{__ros_install_path}/lib/pkgconfig/nns_ros_bridge.pc
+# nodejs
+%exclude %{__ros_install_path}/share/gennodejs/ros/nns_ros_bridge/msg/*.js
+%exclude %{__ros_install_path}/share/gennodejs/ros/nns_ros_bridge/*.js
+# lisp
+%exclude %{__ros_install_path}/share/roseus/ros/nns_ros_bridge/*
+%exclude %{__ros_install_path}/share/common-lisp/ros/nns_ros_bridge/msg/*
+


### PR DESCRIPTION
** PR Description **
This PR mainly addresses Tizen/RPM packaging for GBS/OBS build support. 

Resolves https://github.com/nnsuite/nnstreamer/issues/956
See also: https://github.com/nnsuite/nnstreamer/issues/1059 https://github.com/nnsuite/nnstreamer/issues/1037

- [Build] Replace tensor_common header with plug-in API header
- [CMake] Revise CMake build scripts
- [Git] Add .gitignore file
- [Dist/Tizen] Add RPM spec and manifest files for RPM packaging

Signed-off-by: Wook Song <wook16.song@samsung.com>