### PR TITLE
[RosBridge] Handle errors due to wrong ROS environments

### DIFF
--- a/common/include/nns_ros_bridge.h
+++ b/common/include/nns_ros_bridge.h
@@ -33,6 +33,11 @@
 #include <std_msgs/MultiArrayLayout.h>
 #include <std_msgs/MultiArrayDimension.h>
 
+typedef enum _err_code {
+  UNDEFINED_ROS_MASTER_URI,
+  FAILED_TO_CONNECT_ROSCORE,
+} err_code;
+
 class NnsRosBridge
 {
 public:

--- a/gst/tensor_ros_sink/tensor_ros_sink.c
+++ b/gst/tensor_ros_sink/tensor_ros_sink.c
@@ -403,6 +403,8 @@ gst_tensor_ros_sink_start (GstBaseSink *sink)
       nns_ros_bridge_init (str_pid, GST_ELEMENT_NAME (GST_ELEMENT (sink)));
   g_free (str_pid);
 
+  if (self->nns_ros_bind_instance == NULL)
+    return FALSE;
   return TRUE;
 }
 


### PR DESCRIPTION
This PR needs to be merged before https://github.com/nnsuite/nnstreamer-ros/pull/6

In this PR, handling errors coming from wrong setting in the ROS running environments is added:
- ROS_MASTER_URI is not defined
- the ROS bridge cannot connect to the roscore

**Changes in this PR**
- V2: A patch for adding dependencies on gstreamer-audio-1.0 and gstreamer-video-1.0 is dropped.

Signed-off-by: Wook Song <wook16.song@samsung.com>