### PR TITLE
[Codeowners] Add all nnstreamer members to reviewer list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+# For more details, visit https://help.github.com/articles/about-codeowners/
+# The lists of people and groups are for github.com
+
+# All members of nnstreamer-team are supposed to review each other
+*                                             @nnsuite/nnstreamer @myungjoo @jijoongmoon @again4you @jaeyun-jung @leemgs @wooksong @helloahn @kparichay
+


### PR DESCRIPTION
This patch imports the CODEOWNERS file from the nnstreamer git repository to add all nnstreamer members to reviewer list.

Signed-off-by: Wook Song <wook16.song@samsung.com>