### PR TITLE
[Sink] Add a dummy mode that allows RosSink to run w/o roscore 

### DIFF
--- a/gst/tensor_ros_sink/tensor_ros_sink.h
+++ b/gst/tensor_ros_sink/tensor_ros_sink.h
@@ -68,6 +68,7 @@ struct _GstTensorRosSink
 
   GMutex mutex; /**< mutex for processing */
   gboolean silent; /**< true to print minimized log */
+  gboolean dummy; /**< true to work without roscore */
   gboolean emit_signal; /**< true to emit signal for new data, eos */
   guint signal_rate; /**< new data signals per second */
   GstClockTime last_render_time; /**< buffer rendered time */

--- a/tests/tensor_ros_sink/unittest_tensor_ros_sink.cpp
+++ b/tests/tensor_ros_sink/unittest_tensor_ros_sink.cpp
@@ -30,6 +30,8 @@ TEST (test_tensor_ros_sink, properties)
   gboolean emit_signal, res_emit_signal;
   const gboolean default_silent = TRUE;
   gboolean silent, res_silent;
+  const gboolean default_dummy = FALSE;
+  gboolean dummy, res_dummy;
   GstHarness *hrnss;
 
   hrnss = gst_harness_new ("tensor_ros_sink");
@@ -88,6 +90,14 @@ TEST (test_tensor_ros_sink, properties)
   g_object_set (hrnss->element, "silent", !default_silent, NULL);
   g_object_get (hrnss->element, "silent", &res_silent, NULL);
   EXPECT_EQ (!default_silent, res_silent);
+
+  /** default dummy is FALSE */
+  g_object_get (hrnss->element, "dummy", &dummy, NULL);
+  EXPECT_EQ (default_dummy, dummy);
+
+  g_object_set (hrnss->element, "dummy", !default_dummy, NULL);
+  g_object_get (hrnss->element, "dummy", &res_dummy, NULL);
+  EXPECT_EQ (!default_dummy, res_dummy);
 
   gst_harness_teardown (hrnss);
 }

--- a/tests/tensor_ros_sink/unittest_tensor_ros_sink.cpp
+++ b/tests/tensor_ros_sink/unittest_tensor_ros_sink.cpp
@@ -130,6 +130,8 @@ static void callback_sink_new_data_signal (GstElement* object,
       hrnss = gst_harness_new ("tensor_ros_sink"); \
       ASSERT_TRUE (hrnss != NULL); \
       \
+      g_object_set (hrnss->element, "dummy", TRUE, NULL); \
+      \
       cnt_new_data_signal = 0; \
       sig_id = g_signal_connect (hrnss->element, "new-data", \
           G_CALLBACK (callback_sink_new_data_signal), NULL); \

--- a/tests/tensor_ros_sink/unittest_tensor_ros_sink.cpp
+++ b/tests/tensor_ros_sink/unittest_tensor_ros_sink.cpp
@@ -135,7 +135,7 @@ static void callback_sink_new_data_signal (GstElement* object,
       cnt_new_data_signal = 0; \
       sig_id = g_signal_connect (hrnss->element, "new-data", \
           G_CALLBACK (callback_sink_new_data_signal), NULL); \
-          ASSERT_TRUE (sig_id > 0); \
+      ASSERT_TRUE (sig_id > 0); \
       \
       snprintf (str_dims, SIZE_STR_BUF, "%u:%u:%u:%u", \
           dims[0], dims[1], dims[2], dims[3]); \


### PR DESCRIPTION
Related Issue: https://github.com/nnsuite/nnstreamer/issues/500 https://github.com/nnsuite/nnstreamer/issues/1059

In order to integrate unit test cases into the GBS/OBS/pdebuild systems, this PR added a dummy mode that allows tensor_ros_sink to run without roscore (note that I have verified that 'roscore' does not work in the GBS/OBS environment).

- [Sink] Add a dummy mode that allows RosSink to run w/o roscore 
- [Test/Sink] Add unit test case for newly added property 'dummy' 
- [Test/Sink] Modify test case for 'new-data' signal to run w/o roscore
- [Test/Sink] Fix wrong indentation in TEST_SINK_SIG_NEW_DATA 

Signed-off-by: Wook Song <wook16.song@samsung.com>