### PR TITLE
[DIST/Test] Enable unit tests by default

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,11 +19,12 @@ export DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 %:
 	dh $@ --buildsystem=cmake --builddirectory=build --parallel
 
-export ROS_VERSION ?= kinetic
-export ROS_BASE_PREFIX ?= /opt/ros
-export ROS_INSTALL_PREFIX ?= /opt/ros
-export NNS_INSTALL_PREFIX ?= /usr
-export NNS_INSTALL_LIBDIR ?= lib/${DEB_HOST_MULTIARCH}
+export ROS_VERSION = kinetic
+export ROS_BASE_PREFIX = /opt/ros
+export ROS_INSTALL_PREFIX = /opt/ros
+export NNS_INSTALL_PREFIX = /usr
+export NNS_INSTALL_LIBDIR = lib/${DEB_HOST_MULTIARCH}
+export GST_PLUGIN_PATH=${ROOT_DIR}/build/gst/tensor_ros_sink
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DROS_VERSION=${ROS_VERSION} \
@@ -38,6 +39,9 @@ override_dh_shlibdeps:
 
 override_dh_auto_install:
 	dh_auto_install --DESTDIR=$(CURDIR)/debian/tmp --
+
+override_dh_auto_test:
+	cd build && ./tests/tensor_ros_sink/unittest_tensor_ros_sink -V
 
 override_dh_auto_clean:
 	rm -rf build

--- a/packaging/nnstreamer-ros.spec
+++ b/packaging/nnstreamer-ros.spec
@@ -25,6 +25,8 @@ BuildRequires:  ros-kinetic-message-generation
 BuildRequires:  ros-kinetic-roscpp
 # tizen
 BuildRequires:  pkgconfig(dlog)
+# gtest
+BuildRequires:  gtest-devel
 
 %description
 A set of NNStreamer extension plugins for ROS support
@@ -35,11 +37,17 @@ cp %{SOURCE1001} .
 
 %build
 %{__ros_setup}
-%__ros_build_pkg '-DTIZEN=ON' '-DNNS_INSTALL_LIBDIR=%{_libdir}' '-DENABLE_TEST=OFF'
+%__ros_build_pkg '-DTIZEN=ON' '-DNNS_INSTALL_LIBDIR=%{_libdir}' '-DENABLE_TEST=ON'
 
 %install
 %{__ros_setup}
 %{__ros_install}
+
+%check
+pushd build
+export GST_PLUGIN_PATH=$(pwd)/gst/tensor_ros_sink
+make test ARGS=-V
+popd
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
Related Issue: [nnsuite/nnstreamer#500](https://github.com/nnsuite/nnstreamer/issues/500) [nnsuite/nnstreamer#1059](https://github.com/nnsuite/nnstreamer/issues/1059)
See also: https://github.com/nnsuite/nnstreamer-ros/pull/12 https://github.com/nnsuite/nnstreamer-ros/pull/13

This PR enables unit tests for the build system such as GBS/OBS/pbuilder/debuild by default.

Signed-off-by: Wook Song <wook16.song@samsung.com>