### PR TITLE
[Src] Initial add RosSrc element

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -134,6 +134,10 @@ SET(CXX_SRC_FILES_NNS_ROS_BRIDGE
  ./node/nns_ros_bridge.cc
 )
 
+SET(CXX_SRC_FILES_NNS_ROS_SRC
+ ./node/nns_ros_subscriber.cc
+)
+
 ###########
 ## Build ##
 ###########
@@ -160,6 +164,7 @@ INCLUDE_DIRECTORIES(
 ADD_LIBRARY(nns_ros_bridge ${CXX_SRC_FILES_NNS_ROS_BRIDGE})
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
+ADD_LIBRARY(nns_ros_subscriber ${CXX_SRC_FILES_NNS_ROS_SRC})
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -173,6 +178,11 @@ add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EX
 
 ## Specify libraries to link a library or executable target against
 TARGET_LINK_LIBRARIES(nns_ros_bridge
+  ${catkin_LIBRARIES}
+  ${PKGS_COMMON_LIBRARIES}
+)
+
+TARGET_LINK_LIBRARIES(nns_ros_subscriber
   ${catkin_LIBRARIES}
   ${PKGS_COMMON_LIBRARIES}
 )

--- a/common/include/nns_ros_subscriber.h
+++ b/common/include/nns_ros_subscriber.h
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2019 Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ */
+/**
+ * @file   nns_ros_subscriber.h
+ * @author Sangjung Woo <sangjung.woo@samsung.com>
+ * @date   03/06/2019
+ * @brief  Abstract class for subscribing target Ros topic
+ *
+ * @bug     No known bugs.
+ */
+#ifndef __NNS_ROS_SUBSCRIBER_H__
+#define __NNS_ROS_SUBSCRIBER_H__
+
+#include <glib.h>
+#include <ros/ros.h>
+
+class NnsRosSubscriber {
+public:
+  NnsRosSubscriber (const gchar *node_name,
+    const gchar *topic_name,
+    const gulong rate_usec = G_USEC_PER_SEC,
+    int argc = 0,
+    gchar **argv = NULL);
+  ~NnsRosSubscriber ();
+
+  virtual int RegisterCallback (ros::NodeHandle *nh, ros::Subscriber *sub) = 0;
+  int Start (GThread ** gthread_obj);
+  int RequestStop ();
+
+protected:
+  gchar *node_name;
+  gchar *topic_name;
+
+private:
+  NnsRosSubscriber () {};
+
+  static gpointer ThreadFunc (gpointer userdata);
+
+  ros::NodeHandle *nh;
+  ros::Subscriber sub;
+  gulong rate_usec;
+  gboolean request_stop;
+};
+#endif /* __NNS_ROS_SUBSCRIBER_H__ */

--- a/common/node/nns_ros_subscriber.cc
+++ b/common/node/nns_ros_subscriber.cc
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2019 Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ */
+/**
+ * @file   nns_ros_subscriber.cc
+ * @author Sangjung Woo <sangjung.woo@samsung.com>
+ * @date   03/06/2019
+ * @brief  Abstract class for subscribing target Ros topic
+ *
+ * @bug     No known bugs.
+ */
+#include "nns_ros_subscriber.h"
+
+/**
+ * @brief	The public constructor of this class
+ * @param[in] node_name : The name of the Ros client node
+ * @param[in] topic_name : The name of target topic to subscribe
+ * @param[in] rate_usec : The sampling rate to check the published Ros topic (Default: 1 sec)
+ * @param[in] argc : argc parameter which is used for ros::init (Default: 0)
+ * @param[in] argv : argv parameter which is used for ros::init (Default: NULL)
+ * @return None
+ */
+NnsRosSubscriber::NnsRosSubscriber (const gchar *node_name,
+    const gchar *topic_name,
+    const gulong rate_usec,
+    int argc,
+    gchar **argv)
+{
+  this->node_name = g_strdup (node_name);
+  this->topic_name = g_strdup (topic_name);
+  this->rate_usec = rate_usec;
+  this->request_stop = false;
+
+  ros::init (argc, argv, this->node_name);
+}
+
+/**
+ *  @brief The destructor of this class
+ */
+NnsRosSubscriber::~NnsRosSubscriber ()
+{
+  if (this->node_name)
+    g_free (this->node_name);
+  
+  if (this->topic_name)
+    g_free (this->topic_name);
+}
+
+/**
+ * @brief	A method for starting thread to subscribe target Ros topic
+ * @param[in] gthread_obj : GThread pointer
+ * @return 0 when thread is created and running
+ */
+int
+NnsRosSubscriber::Start (GThread ** gthread_obj)
+{
+  this->nh = new ros::NodeHandle();
+
+  /* Call the subclass's method */
+  RegisterCallback (this->nh, &this->sub);
+  *gthread_obj = g_thread_new ("RosSubThread", (GThreadFunc)NnsRosSubscriber::ThreadFunc, this);
+
+  return 0;
+}
+
+/**
+ * @brief	A metohd to stop running thread for subscribing Ros topic
+ * @return 0 if request_stop is set as true
+ */
+int
+NnsRosSubscriber::RequestStop ()
+{
+  this->request_stop = true;
+  return 0;
+}
+
+/**
+ * @brief	A method for checking published Ros topic on a desinated cycle
+ * @param[in] gpointer which points NnsRosSubscriber instance
+ * @return NULL when running thread exits
+ */
+gpointer
+NnsRosSubscriber::ThreadFunc (gpointer userdata)
+{
+  NnsRosSubscriber *rossub = static_cast <NnsRosSubscriber *> (userdata);
+  while (TRUE) {
+    if (rossub->request_stop) {
+      g_printerr ("Sub thread is going to stop!\n");
+      break;
+    }
+
+    /* check the ros topic */
+    ros::spinOnce();
+    g_usleep (rossub->rate_usec);
+  }
+  g_thread_exit (GINT_TO_POINTER (0));
+
+  return NULL;
+}

--- a/gst/CMakeLists.txt
+++ b/gst/CMakeLists.txt
@@ -1,1 +1,2 @@
 ADD_SUBDIRECTORY(tensor_ros_sink)
+ADD_SUBDIRECTORY(tensor_ros_src)

--- a/gst/tensor_ros_src/CMakeLists.txt
+++ b/gst/tensor_ros_src/CMakeLists.txt
@@ -1,0 +1,27 @@
+SET(ROSSRC_PKG_MODULES
+  gstreamer-base-1.0
+  roscpp
+  std_msgs
+)
+
+PKG_CHECK_MODULES(PKGS REQUIRED ${ROSSRC_PKG_MODULES})
+
+LINK_DIRECTORIES(${PKGS_LIBRARY_DIRS})
+
+ADD_LIBRARY(tensor_ros_src tensor_ros_src.cc tensor_ros_listener.cc)
+ADD_DEPENDENCIES(tensor_ros_src nns_ros_subscriber)
+TARGET_INCLUDE_DIRECTORIES(tensor_ros_src PRIVATE
+  ${PKGS_INCLUDE_DIRS}
+)
+
+TARGET_LINK_LIBRARIES(tensor_ros_src
+  nns_ros_subscriber
+  ${PKGS_COMMON_LIBRARIES}
+  ${PKGS_LIBRARIES}
+)
+
+INSTALL(TARGETS tensor_ros_src
+  RUNTIME DESTINATION ${NNS_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${NNS_INSTALL_GSTDIR}
+  ARCHIVE DESTINATION ${NNS_INSTALL_LIBDIR}
+)

--- a/gst/tensor_ros_src/tensor_ros_listener.cc
+++ b/gst/tensor_ros_src/tensor_ros_listener.cc
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2019 Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ */
+/**
+ * @file   tensor_ros_lintener.cc
+ * @author Sangjung Woo <sangjung.woo@samsung.com>
+ * @date   03/06/2019
+ * @brief  A bridge for ROS support within NNStreamer
+ *
+ * This class bridges between the NNStreamer (C) and ROS frameworks (ROSCPP/C++).
+ *
+ * @bug     No known bugs.
+ */
+#include <tensor_typedef.h>
+
+#include "tensor_ros_listener.h"
+
+/**
+ * @brief	The public constructor of Int32RosListener
+ * @param[in] rossrc : GstTensorRosSrc instance
+ * @return None
+ */
+Int32RosListener::Int32RosListener (GstTensorRosSrc *rossrc)
+{
+  this->rossrc = rossrc;
+  this->payload_size = rossrc->count * tensor_element_size[rossrc->datatype];
+}
+
+/**
+ * @brief	A Callback method when target Ros topic is published
+ * @param[in] msg : Published message
+ * @return None
+ */
+void
+Int32RosListener::Callback(const std_msgs::Int32MultiArray msg)
+{
+  /* Get the payload of message and enqueue them into GAsyncQueue */
+  gpointer queue_item = g_malloc0 (this->payload_size);
+
+  std::memcpy (queue_item, msg.data.data(), this->payload_size);
+  g_async_queue_push (this->rossrc->queue, queue_item);
+
+  GST_DEBUG_OBJECT (this->rossrc, "Queue size: %d\n", g_async_queue_length (this->rossrc->queue));
+}

--- a/gst/tensor_ros_src/tensor_ros_listener.h
+++ b/gst/tensor_ros_src/tensor_ros_listener.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2019 Samsung Electronics Co., Ltd. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ */
+/**
+ * @file   tensor_ros_lintener.h
+ * @author Sangjung Woo <sangjung.woo@samsung.com>
+ * @date   03/06/2019
+ * @brief  A set of Ros Listener classes for various types
+ *
+ * @bug     No known bugs except for NYI items
+ */
+
+#include <std_msgs/Int32MultiArray.h>
+#include <std_msgs/Int32.h>
+
+#include "tensor_ros_src.h"
+
+/**
+ * @brief Ros Listener class for Int32 type
+ */
+class Int32RosListener {
+  private:
+    GstTensorRosSrc *rossrc;    /*<< GstTensorRosSrc instance */
+    int payload_size;           /*<< The payload size of Ros message */
+
+  public:
+    Int32RosListener (GstTensorRosSrc *rossrc);
+    void Callback(const std_msgs::Int32MultiArray msg);
+};

--- a/gst/tensor_ros_src/tensor_ros_src.cc
+++ b/gst/tensor_ros_src/tensor_ros_src.cc
@@ -1,0 +1,464 @@
+/*
+ * GStreamer
+ * Copyright (C) 2005 Thomas Vander Stichele <thomas@apestaart.org>
+ * Copyright (C) 2005 Ronald S. Bultje <rbultje@ronald.bitfreak.net>
+ * Copyright (C) 2019 Samsung Electronics Co., Ltd.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ */
+
+/**
+ * SECTION:element-tensor_ros_src
+ *
+ * Source element to publish tensor stream from deginated Ros topic
+ *
+ * @file    tensor_ros_src.cc
+ * @date    03/06/2019
+ * @brief   GStreamer plugin to subscribe a Ros topic and convert them into tensor stream
+ * @see     https://github.com/nnsuite/nnstreamer-ros
+ * @author  Sangjung Woo <sangjung.woo@samsung.com>
+ * @bug     No known bugs except for NYI items
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include <config.h>
+#endif
+
+#include <tensor_typedef.h>
+#include <string.h>
+
+#include "tensor_ros_src.h"
+#include "tensor_ros_listener.h"
+
+GST_DEBUG_CATEGORY_STATIC (gst_tensor_ros_src_debug);
+#define GST_CAT_DEFAULT gst_tensor_ros_src_debug
+
+#define SUPPORTED_CAPS_STRING   "application/octet-stream"
+#define DEFAULT_ROS_QUEUE_SIZE  1000
+
+/** ROS Listener instance for each type */
+static Int32RosListener *int32RosListener;
+
+/**
+ * @brief Concrete Ros Subscriber class
+ */
+class TensorRosSub : public NnsRosSubscriber {
+  private:
+    GstTensorRosSrc *rossrc;
+
+  public:
+    TensorRosSub (const gchar *node_name,
+      const gchar *topic_name,
+      GstTensorRosSrc *rossrc,
+      const gulong rate_usec = G_USEC_PER_SEC,
+      int argc = 0,
+      gchar **argv = NULL) : NnsRosSubscriber (node_name, topic_name, rate_usec, argc, argv)
+      {
+        this->rossrc = rossrc;
+      }
+
+      virtual int RegisterCallback (ros::NodeHandle *nh, ros::Subscriber *sub);
+};
+
+/**
+ * @brief register callback function to subscribe ROS topic
+ */
+int
+TensorRosSub::RegisterCallback (ros::NodeHandle *nh, ros::Subscriber *sub)
+{
+  GST_DEBUG_OBJECT (this->rossrc, "[%s]", __func__);
+
+  switch (this->rossrc->datatype) {
+    /* TODO: Need to add more types */
+    case _NNS_UINT32:
+      GST_DEBUG_OBJECT (rossrc, "Not implementation yet!\n");
+      break;
+
+    case _NNS_INT32:
+    default:
+      int32RosListener = new Int32RosListener(this->rossrc);
+      *sub = nh->subscribe (this->topic_name, DEFAULT_ROS_QUEUE_SIZE, 
+        &Int32RosListener::Callback, int32RosListener);
+      break;
+
+  }
+  return 0;
+}
+
+/**
+ * @brief tensor_ros_src properties
+ */
+enum
+{
+  PROP_0,
+  PROP_SILENT,      /*<< Slient mode for debug */
+  PROP_TOPIC,       /*<< ROS topic name to subscribe */
+  PROP_FREQ_RATE,   /*<< frequency rate to check the published topic */
+  PROP_DATATYPE,    /*<< Primitive datatype of ROS topic */
+  PROP_INPUT_DIMS,  /*<< Input dimension of Target ROS topic */
+};
+
+/**
+ * @brief Template for ros source pad
+ */
+static GstStaticPadTemplate src_pad_template =
+GST_STATIC_PAD_TEMPLATE ("src",
+    GST_PAD_SRC,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS (SUPPORTED_CAPS_STRING));
+
+#define gst_tensor_ros_src_parent_class parent_class
+G_DEFINE_TYPE (GstTensorRosSrc, gst_tensor_ros_src, GST_TYPE_PUSH_SRC);
+
+/** GObject method implementation */
+static void gst_tensor_ros_src_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec);
+static void gst_tensor_ros_src_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec);
+static void gst_tensor_ros_src_dispose (GObject * object);
+
+/** GstElement method implementation */
+static GstStateChangeReturn
+gst_tensor_ros_src_change_state (GstElement * element, GstStateChange transition);
+
+/** GstPushSrc method implementation */
+static GstFlowReturn 
+gst_tensor_ros_src_create (GstPushSrc * src, GstBuffer ** buffer);
+
+/**
+ * @brief The primitive type of Ros
+ */
+static const gchar* str_type[] = {"int32", "uint32",
+  "int16", "uint16",
+  "int8", "uint8",
+  "float64", "float32",
+  "int64", "uint64"};
+
+/**
+ * @brief Get tensor_type enum value from the type name
+ */
+static tensor_type
+get_tensor_type (const gchar * type_name)
+{
+  int type_count = sizeof(str_type);
+  for (int i = 0; i < type_count; ++i) {
+    if (!g_strcmp0 (type_name, str_type[i]))
+      return static_cast<tensor_type> (i);
+  }
+  return _NNS_END;
+}
+
+/**
+ * @brief Get the type name from tensor_type enum value
+ */
+static const gchar *
+get_string_type (tensor_type type)
+{
+  return str_type[type];
+}
+
+/**
+ * @brief Get the total count of input message (e.g. 10:2:1:1 means 20 since 10 * 2 * 1 * 1)
+ */
+static guint
+get_item_count (const gchar* dim_str)
+{
+  guint count = 0;
+
+  if (dim_str) {
+    gchar **dims = g_strsplit (dim_str, ":", -1);
+    guint rank = g_strv_length (dims);
+    count = atoi (dims[0]);
+    for (unsigned int i = 1; i < rank; ++i) {
+      count = count * atoi (dims[i]);
+    }
+  }
+  return count;
+}
+
+/**
+ * @brief initialize the rossrc's class
+ */
+static void
+gst_tensor_ros_src_class_init (GstTensorRosSrcClass * klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
+  GstPushSrcClass *gstpushsrc_class = GST_PUSH_SRC_CLASS (klass);
+
+  /* GObject method */
+  gobject_class->set_property = gst_tensor_ros_src_set_property;
+  gobject_class->get_property = gst_tensor_ros_src_get_property;
+  gobject_class->dispose = gst_tensor_ros_src_dispose;  
+
+  /* GstElement method for state change */
+  gstelement_class->change_state =
+    GST_DEBUG_FUNCPTR (gst_tensor_ros_src_change_state);
+
+  /* GstPushSrc method */
+  gstpushsrc_class->create = gst_tensor_ros_src_create;
+
+  /* Add property */
+  g_object_class_install_property (gobject_class, PROP_SILENT,
+    g_param_spec_boolean ("silent", "Silent", "Produce verbose output ?",
+        FALSE, G_PARAM_READWRITE));
+  
+  g_object_class_install_property (gobject_class, PROP_TOPIC,
+    g_param_spec_string ("topic", "Topic",
+      "ROS Topic Name for subscription", "",
+      (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_FREQ_RATE,
+    g_param_spec_ulong ("freqrate", "Frequency_Rate",
+      "Frequency rate for checking Ros Topic(Hz, Default: 1Hz)",
+      1, G_USEC_PER_SEC, 1, G_PARAM_READWRITE));
+
+  g_object_class_install_property (gobject_class, PROP_DATATYPE,
+    g_param_spec_string ("datatype", "Datatype",
+      "Primitive datatype of target ROS topic", "",
+      (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_INPUT_DIMS,
+    g_param_spec_string ("input", "Input dimension",
+      "Input dimension of target ROS topic", "",
+      (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  gst_element_class_add_static_pad_template (gstelement_class,
+    &src_pad_template);
+
+  gst_element_class_set_static_metadata (gstelement_class,
+    "TensorRosSrc",
+    "Source/Tensor",
+    "Source element to get the topic data from ROS node",
+    "Samsung Electronics Co., Ltd.");
+}
+
+/**
+ * @brief Initialize ensor_ros_src element
+ */
+static void
+gst_tensor_ros_src_init (GstTensorRosSrc * rossrc)
+{
+  /* set the default properties */
+  rossrc->silent = FALSE;
+  rossrc->topic_name = NULL;
+  rossrc->freq_rate = G_USEC_PER_SEC;
+  rossrc->queue = g_async_queue_new ();
+}
+
+/**
+ * @brief Dispose allocated resources
+ */
+static void
+gst_tensor_ros_src_dispose (GObject * object)
+{
+  GstTensorRosSrc *rossrc = GST_TENSOR_ROS_SRC (object);
+
+  if (rossrc->caps)
+    gst_caps_unref (rossrc->caps);
+
+  if (rossrc->queue)
+    g_async_queue_unref (rossrc->queue);
+
+  if (rossrc->topic_name)
+    g_free (rossrc->topic_name);
+
+  if (rossrc->input_dims)
+    g_free (rossrc->input_dims);
+
+  G_OBJECT_CLASS (parent_class)->dispose (object);
+}
+
+/**
+ * @brief Setter for tensor_ros_src properties
+ */
+static void
+gst_tensor_ros_src_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  GstTensorRosSrc *rossrc = GST_TENSOR_ROS_SRC (object);
+
+  switch (prop_id) {
+    case PROP_SILENT:
+      rossrc->silent = g_value_get_boolean (value);
+      break;
+
+    case PROP_TOPIC:
+      rossrc->topic_name = g_strdup(g_value_get_string (value));
+      GST_DEBUG_OBJECT (rossrc, "topic name: %s\n", rossrc->topic_name);
+      break;
+
+    case PROP_FREQ_RATE:
+      rossrc->freq_rate = G_USEC_PER_SEC / g_value_get_ulong (value);
+      GST_DEBUG_OBJECT (rossrc, "Freq Hz: %lu\n", G_USEC_PER_SEC / rossrc->freq_rate);
+      break;
+
+    case PROP_DATATYPE:
+      rossrc->datatype = get_tensor_type (g_value_get_string (value));
+      GST_DEBUG_OBJECT (rossrc, "Datatype: %s\n", get_string_type(rossrc->datatype));
+      break;
+
+    case PROP_INPUT_DIMS:
+      rossrc->input_dims = g_strdup(g_value_get_string (value));
+      rossrc->count = get_item_count (rossrc->input_dims);
+      GST_DEBUG_OBJECT (rossrc, "Item count: %u\n", rossrc->count);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief Getter for tensor_ros_src properties
+ */
+static void
+gst_tensor_ros_src_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  GstTensorRosSrc *rossrc = GST_TENSOR_ROS_SRC (object);
+
+  switch (prop_id) {
+    case PROP_SILENT:
+      g_value_set_boolean (value, rossrc->silent);
+      break;
+    
+    case PROP_TOPIC:
+      g_value_set_string (value, rossrc->topic_name);
+      break;
+
+    case PROP_FREQ_RATE:
+      g_value_set_ulong (value, G_USEC_PER_SEC / rossrc->freq_rate);
+      break;
+
+    case PROP_DATATYPE:
+      g_value_set_string (value, get_string_type(rossrc->datatype));
+      break;
+
+    case PROP_INPUT_DIMS:
+      g_value_set_string (value, rossrc->input_dims);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+      break;
+  }
+}
+
+/**
+ * @brief Getter for tensor_ros_src properties
+ */
+static GstStateChangeReturn
+gst_tensor_ros_src_change_state (GstElement * element, GstStateChange transition)
+{
+  GstTensorRosSrc *rossrc = GST_TENSOR_ROS_SRC (element);
+  GstStateChangeReturn ret;
+
+  /* handle before change */
+  switch (transition) {
+    case GST_STATE_CHANGE_NULL_TO_READY:
+      /* create thread */
+      GST_DEBUG_OBJECT (rossrc, "State is changed: GST_STATE_CHANGE_NULL_TO_READY\n");
+      rossrc->ros_sub = new TensorRosSub ("TensorRosSub", rossrc->topic_name,
+        rossrc, rossrc->freq_rate);
+      rossrc->ros_sub->Start (&rossrc->thread);
+      break;
+
+    default:
+      break;
+  }
+
+  ret = GST_ELEMENT_CLASS (parent_class)->change_state (element, transition);
+
+  /* handle after change */
+  switch (transition) {
+    case GST_STATE_CHANGE_READY_TO_NULL:
+      /* stop thread */
+      GST_DEBUG_OBJECT (rossrc, "State is changed: GST_STATE_CHANGE_READY_TO_NULL\n");
+      rossrc->ros_sub->RequestStop ();
+      break;
+
+    default:
+      break;
+  }
+
+  return ret;
+}
+
+/**
+ * @brief Push GstBuffer which contains the subscribed ROS data
+ */
+static GstFlowReturn
+gst_tensor_ros_src_create (GstPushSrc * src, GstBuffer ** buffer)
+{
+  gpointer queue_item = NULL;
+  GstTensorRosSrc *rossrc = GST_TENSOR_ROS_SRC (src);
+  GstBuffer *buf = NULL;
+  GstMemory *mem;
+  GstMapInfo info;
+  gsize size = rossrc->count * tensor_element_size[rossrc->datatype];
+
+  /* get item from queue */
+  queue_item = g_async_queue_try_pop (rossrc->queue);
+
+  buf = gst_buffer_new ();
+  mem = gst_allocator_alloc (NULL, size, NULL);
+  gst_memory_map (mem, &info, GST_MAP_WRITE);
+
+  if (queue_item == NULL) {
+    memset (info.data, 0x00, size);
+  } else {
+    info.data = static_cast<guint8 *>(queue_item);
+    info.size = size;
+  }
+
+  gst_memory_unmap (mem, &info);
+  gst_buffer_append_memory (buf, mem);
+
+  *buffer = buf;
+  GST_DEBUG_OBJECT (rossrc, "Buffer of TensorRosSrc is pushed! (queue size: %d)\n",
+    g_async_queue_length (rossrc->queue));
+
+  return GST_FLOW_OK;
+}
+
+ /**
+ * @brief Initialize the tensor_ros_src plugin
+ */
+static gboolean
+gst_tensor_ros_src_plugin_init (GstPlugin * rossrc)
+{
+  GST_DEBUG_CATEGORY_INIT (gst_tensor_ros_src_debug, "tensor_ros_src",
+      0, "Source element to get the topic data from ROS node");
+
+  return gst_element_register (rossrc, "tensor_ros_src", GST_RANK_NONE,
+      GST_TYPE_TENSOR_ROS_SRC);
+}
+
+#ifndef PACKAGE
+#define PACKAGE "nnstreamer-ros"
+#endif
+
+/**
+ * @brief Macro to define the entry point of the plugin.
+ */
+GST_PLUGIN_DEFINE (
+    GST_VERSION_MAJOR,
+    GST_VERSION_MINOR,
+    tensor_ros_src,
+    "Source element to get the topic data from ROS node",
+    gst_tensor_ros_src_plugin_init,
+    NNS_VERSION,
+    "LGPL",
+    "nnstreamer-ros",
+    "https://github.com/nnsuite/nnstreamer-ros"
+)

--- a/gst/tensor_ros_src/tensor_ros_src.h
+++ b/gst/tensor_ros_src/tensor_ros_src.h
@@ -1,0 +1,79 @@
+/**
+ * GStreamer
+ * Copyright (C) 2005 Thomas Vander Stichele <thomas@apestaart.org>
+ * Copyright (C) 2005 Ronald S. Bultje <rbultje@ronald.bitfreak.net>
+ * Copyright (C) 2019 Samsung Electronics Co., Ltd.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ */
+
+/**
+ * @file	tensor_ros_src.h
+ * @date	03/06/2019
+ * @brief	GStreamer plugin to handle tensor stream from Ros topic
+ * @see		https://github.com/nnsuite/nnstreamer
+ * @see		https://github.com/nnsuite/nnstreamer-ros
+ * @author	Sangjung Woo <sangjung.woo@samsung.com>
+ * @bug		No known bugs except for NYI items
+ */
+
+#ifndef __GST_TENSOR_ROS_SRC_H__
+#define __GST_TENSOR_ROS_SRC_H__
+
+#include <gst/gst.h>
+#include <gst/base/gstpushsrc.h>
+
+#include "nns_ros_subscriber.h"
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_TENSOR_ROS_SRC \
+  (gst_tensor_ros_src_get_type())
+#define GST_TENSOR_ROS_SRC(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_TENSOR_ROS_SRC,GstTensorRosSrc))
+#define GST_TENSOR_ROS_SRC_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_TENSOR_ROS_SRC,GstTensorRosSrcClass))
+#define GST_IS_TENSOR_ROS_SRC(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_TENSOR_ROS_SRC))
+#define GST_IS_TENSOR_ROS_SRC_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TENSOR_ROS_SRC))
+
+typedef struct _GstTensorRosSrc GstTensorRosSrc;
+typedef struct _GstTensorRosSrcClass GstTensorRosSrcClass;
+
+struct _GstTensorRosSrc
+{
+  GstPushSrc parent;
+
+  GstCaps *caps;
+  gboolean silent;
+  GThread *thread;        /** ros subscribe thread */
+
+  gchar *topic_name;      /** ROS topic name to subscribe */
+  gchar *input_dims;      /** input dimemsion of ROS message */
+  guint count;            /** total item count of ROS message */
+  tensor_type datatype;   /** Primitive datatype of ROS topic */
+  gulong freq_rate;       /** frequency rate to check */
+
+  GAsyncQueue *queue;     /** data queue */
+  class NnsRosSubscriber *ros_sub;    /** NnsRosSubscriber instance for subscribing Ros topic in other thread */
+};
+
+struct _GstTensorRosSrcClass 
+{
+  GstPushSrcClass parent_class;
+};
+
+GType gst_ros_src_get_type (void);
+
+G_END_DECLS
+
+#endif /* __GST_TENSOR_ROS_SRC_H__ */


### PR DESCRIPTION
This PR newly adds the RosSrc element and its related classes. This version focuses on fetching Ros topic so tensor_converter _should_ be used to convert the tensor. However, it provides more flexibility with sophisticated tailoring.

### Element parameter
* topic: ROS Topic Name for subscription (Required)
* freqrate: Frequency rate for checking Ros Topic(Hz, Default: 1Hz)
* datatype: Primitive datatype of target ROS topic (Default: int32)
* input: Input dimension of target ROS topic (e.g. 10:1:1:1)

### Known issue
* Only support int32 type (because of _fast_ review)
* Test code is omitted (because of _fast_ review but this PR works without any errors)
* `tensor_converter` is required to convert the tensor stream
  * `tensor_converter` functionality is merged into _another_ version.

### Examples
* With full parameters
```bash
$ GST_DEBUG=tensor_ros_src:5 gst-launch-1.0 --gst-plugin-path="./gst/tensor_ros_src/" \
tensor_ros_src topic=TestTopic freqrate=1 datatype=int32 input=10:1:1:1 ! \
application/octet-stream,framerate=1/2 ! \
tensor_converter input-dim=5:1:1:1 input-type=int32 ! tensor_sink
```

* With minimum parameters
```bash
$ GST_DEBUG=tensor_ros_src:5 gst-launch-1.0 --gst-plugin-path="./gst/tensor_ros_src/" \
tensor_ros_src topic=TestTopic input=10:1:1:1 ! \
application/octet-stream,framerate=1/2 ! \
tensor_converter input-dim=5:1:1:1 input-type=int32 ! tensor_sink
```

### Detailed information for this element
```
$ gst-inspect-1.0 tensor_ros_src --gst-plugin-path="./gst/tensor_ros_src/"
Factory Details:
  Rank                     none (0)
  Long-name                TensorRosSrc
  Klass                    Source/Tensor
  Description              Source element to get the topic data from ROS node
  Author                   Samsung Electronics Co., Ltd.

Plugin Details:
  Name                     tensor_ros_src
  Description              Source element to get the topic data from ROS node
  Filename                 ./gst/tensor_ros_src/libtensor_ros_src.so
  Version                  0.0.3
  License                  LGPL
  Source module            nnstreamer-ros
  Binary package           nnstreamer-ros
  Origin URL               https://github.com/nnsuite/nnstreamer-ros

GObject
 +----GInitiallyUnowned
       +----GstObject
             +----GstElement
                   +----GstBaseSrc
                         +----GstPushSrc
                               +----GstTensorRosSrc
...
```