### PR TITLE
[Test/Sink] Add rosbag-based pipeline test cases for videotestsrc/audiotestsrc

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,10 +4,11 @@ Priority: optional
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
 Build-Depends: gcc (>=5), cmake, debhelper (>=9),
  libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, libglib2.0-dev,
- gstreamer1.0-tools, libgtest-dev, ssat, python2.7, nnstreamer-dev,
+ gstreamer1.0-plugins-base, gstreamer1.0-tools,
+ libgtest-dev, ssat, python2.7, nnstreamer-dev,
  ros-kinetic-catkin, ros-kinetic-cmake-modules,
  ros-kinetic-genmsg, ros-kinetic-message-generation,
- ros-kinetic-roscpp
+ ros-kinetic-roscpp, ros-kinetic-rosbag
 Standards-Version: 3.9.7
 Homepage: https://github.com/nnsuite/nnstreamer-ros
 

--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,7 @@ export DH_VERBOSE = 1
 ROOT_DIR:=$(shell pwd)
 export DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 export DEB_HOST_ARCH ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
+export GST_PLUGIN_PATH=${ROOT_DIR}/build/gst/nnstreamer
 
 %:
 	dh $@ --buildsystem=cmake --builddirectory=build --parallel
@@ -41,7 +42,10 @@ override_dh_auto_install:
 	dh_auto_install --DESTDIR=$(CURDIR)/debian/tmp --
 
 override_dh_auto_test:
-	cd build && ./tests/tensor_ros_sink/unittest_tensor_ros_sink -V
+	cd build && ./tests/tensor_ros_sink/unittest_tensor_ros_sink -V && cd ${ROOT_DIR}
+	. build/devel/setup.sh && cd tests && ssat
 
 override_dh_auto_clean:
 	rm -rf build
+	find . -name *.log | xargs rm -f
+	find . -name *.bag | xargs rm -f

--- a/packaging/nnstreamer-ros.spec
+++ b/packaging/nnstreamer-ros.spec
@@ -30,6 +30,9 @@ BuildRequires:  pkgconfig(bzip2)
 BuildRequires:  pkgconfig(liblz4)
 # gtest
 BuildRequires:  gtest-devel
+# Unit Testing Uses SSAT (hhtps://github.com/myungjoo/SSAT.git)
+BuildRequires: ssat
+BuildRequires: python
 
 %description
 A set of NNStreamer extension plugins for ROS support
@@ -50,6 +53,10 @@ cp %{SOURCE1001} .
 pushd build
 export GST_PLUGIN_PATH=$(pwd)/gst/tensor_ros_sink
 make test ARGS=-V
+popd
+pushd tests
+%{__ros_setup}
+ssat -n
 popd
 
 %files

--- a/tests/tensor_ros_sink/CMakeLists.txt
+++ b/tests/tensor_ros_sink/CMakeLists.txt
@@ -1,6 +1,7 @@
 SET(PKG_MODULES
   gstreamer-base-1.0
   gstreamer-check-1.0
+  gstreamer-plugins-base-1.0
 )
 
 FIND_LIBRARY(GTEST_LIB gtest)

--- a/tests/tensor_ros_sink/runTest.sh
+++ b/tests/tensor_ros_sink/runTest.sh
@@ -18,18 +18,48 @@ testInit "rosbag-based pipeline test"
 
 PATH_TO_PLUGIN="../../build"
 
-gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=BGRx,width=280,height=40,framerate=0/1 ! tee name=t ! queue ! tensor_converter silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.uint8.BGRx.bag\" sync=true t. ! queue ! filesink location=\"simple.uint8.BGRx.log\" sync=true" 1-1
+gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=BGRx,width=280,height=40,framerate=0/1 ! tee name=t ! queue ! tensor_converter silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.BGRx.uint8.bag\" sync=true t. ! queue ! filesink location=\"simple.BGRx.uint8.log\" sync=true" 1-1
+../test_utils.py simple.BGRx.uint8.log simple.BGRx.uint8.bag BGRx uint8 280 40
+testResult $? 1-1 "tensor_ros_sink: simple test case using raw data (video/BGRx/uint8)" 0 1
 
-../test_utils.py simple.uint8.BGRx.log simple.uint8.BGRx.bag uint8 BGRx 280 40
-testResult $? 1-1 "tensor_ros_sink: simple test case for raw data (uint8/BGRx)" 0 1
+gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40,framerate=0/1 ! tee name=t ! queue ! tensor_converter silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.RGB.uint8.bag\" sync=true t. ! queue ! filesink location=\"simple.RGB.uint8.log\" sync=true" 1-2
+../test_utils.py simple.RGB.uint8.log simple.RGB.uint8.bag RGB uint8 280 40
+testResult $? 1-2 "tensor_ros_sink: simple test case using raw data (video/RGB/uint8)" 0 1
 
-gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40,framerate=0/1 ! tee name=t ! queue ! tensor_converter silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.uint8.RGB.bag\" sync=true t. ! queue ! filesink location=\"simple.uint8.RGB.log\" sync=true" 1-2
-../test_utils.py simple.uint8.RGB.log simple.uint8.RGB.bag uint8 RGB 280 40
-testResult $? 1-2 "tensor_ros_sink: simple test case for raw data (uint8/RGB)" 0 1
+gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=GRAY8,width=280,height=40,framerate=0/1 ! tee name=t ! queue ! tensor_converter silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.GRAY8.uint8.bag\" sync=true t. ! queue ! filesink location=\"simple.GRAY8.uint8.log\" sync=true" 1-3
+../test_utils.py simple.GRAY8.uint8.log simple.GRAY8.uint8.bag GRAY8 uint8 280 40
+testResult $? 1-3 "tensor_ros_sink: simple test case using raw data (video/GRAY8/uint8)" 0 1
 
-gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=GRAY8,width=280,height=40,framerate=0/1 ! tee name=t ! queue ! tensor_converter silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.uint8.GRAY8.bag\" sync=true t. ! queue ! filesink location=\"simple.uint8.GRAY8.log\" sync=true" 1-3
-../test_utils.py simple.uint8.GRAY8.log simple.uint8.GRAY8.bag uint8 GRAY8 280 40
-testResult $? 1-3 "tensor_ros_sink: simple test case for raw data (uint8/GRAY8)" 0 1
+# audio format mono, S16LE, 8k sample rate, samples per buffer 8000
+gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=S16LE,rate=8000,channels=1 ! tee name=t ! queue ! tensor_converter frames-per-tensor=8000 silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.audio.1.s16le.8k.bag\" sync=true t. ! queue ! filesink location=\"simple.audio.1.s16le.8k.log\" sync=true" 2-1
+../test_utils.py simple.audio.1.s16le.8k.log simple.audio.1.s16le.8k.bag 1 s16le 8000
+testResult $? 2-1 "tensor_ros_sink: simple test case using raw data (audio/mono/s16le/8k)" 0 1
+
+# audio format stereo, S16LE, 8k sample rate, samples per buffer 8000
+gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=S16LE,rate=8000,channels=2 ! tee name=t ! queue ! tensor_converter frames-per-tensor=8000 silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.audio.2.s16le.8k.bag\" sync=true t. ! queue ! filesink location=\"simple.audio.2.s16le.8k.log\" sync=true" 2-2
+../test_utils.py simple.audio.2.s16le.8k.log simple.audio.2.s16le.8k.bag 2 s16le 8000
+testResult $? 2-2 "tensor_ros_sink: simple test case using raw data (audio/stereo/s16le/8k)" 0 1
+
+# audio format mono, F32LE, 8k sample rate, samples per buffer 8000
+gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=F32LE,rate=8000,channels=1 ! tee name=t ! queue ! tensor_converter frames-per-tensor=8000 silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.audio.1.f32le.8k.bag\" sync=true t. ! queue ! filesink location=\"simple.audio.1.f32le.8k.log\" sync=true" 2-3
+../test_utils.py simple.audio.1.f32le.8k.log simple.audio.1.f32le.8k.bag 1 f32le 8000
+testResult $? 2-3 "tensor_ros_sink: simple test case using raw data (audio/mono/f32le/8k)" 0 1
+
+# audio format stereo, F32LE, 8k sample rate, samples per buffer 8000
+gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=F32LE,rate=8000,channels=2 ! tee name=t ! queue ! tensor_converter frames-per-tensor=8000 silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.audio.2.f32le.8k.bag\" sync=true t. ! queue ! filesink location=\"simple.audio.2.f32le.8k.log\" sync=true" 2-4
+../test_utils.py simple.audio.2.f32le.8k.log simple.audio.2.f32le.8k.bag 2 f32le 8000
+testResult $? 2-4 "tensor_ros_sink: simple test case using raw data (audio/stereo/f32le/8k)" 0 1
+
+# audio format mono, F64LE, 8k sample rate, samples per buffer 8000
+gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=F64LE,rate=8000,channels=1 ! tee name=t ! queue ! tensor_converter frames-per-tensor=8000 silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.audio.1.f64le.8k.bag\" sync=true t. ! queue ! filesink location=\"simple.audio.1.f64le.8k.log\" sync=true" 2-5
+../test_utils.py simple.audio.1.f64le.8k.log simple.audio.1.f64le.8k.bag 1 f64le 8000
+testResult $? 2-5 "tensor_ros_sink: simple test case using raw data (audio/mono/f64le/8k)" 0 1
+
+# audio format stereo, F64LE, 8k sample rate, samples per buffer 8000
+gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} audiotestsrc num-buffers=1 samplesperbuffer=8000 ! audioconvert ! audio/x-raw,format=F64LE,rate=8000,channels=2 ! tee name=t ! queue ! tensor_converter frames-per-tensor=8000 silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.audio.2.f64le.8k.bag\" sync=true t. ! queue ! filesink location=\"simple.audio.2.f64le.8k.log\" sync=true" 2-6
+../test_utils.py simple.audio.2.f64le.8k.log simple.audio.2.f64le.8k.bag 2 f64le 8000
+testResult $? 2-6 "tensor_ros_sink: simple test case using raw data (audio/stereo/f64le/8k)" 0 1
+
 
 report
 

--- a/tests/tensor_ros_sink/runTest.sh
+++ b/tests/tensor_ros_sink/runTest.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+##
+## @file runTest.sh
+## @author Wook Song <wook16.song@gmail.com>
+## @date  2월 28 2019
+## @brief SSAT test cases for NNStreamer-ros
+#
+if [[ "$SSATAPILOADED" != "1" ]]
+then
+	SILENT=0
+	INDEPENDENT=1
+	search="ssat-api.sh"
+	source $search
+	printf "${Blue}Independent Mode${NC}
+"
+fi
+testInit "rosbag-based pipeline test"
+
+PATH_TO_PLUGIN="../../build"
+
+gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=BGRx,width=280,height=40,framerate=0/1 ! tee name=t ! queue ! tensor_converter silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.uint8.BGRx.bag\" sync=true t. ! queue ! filesink location=\"simple.uint8.BGRx.log\" sync=true" 1-1
+
+../test_utils.py simple.uint8.BGRx.log simple.uint8.BGRx.bag uint8 BGRx 280 40
+testResult $? 1-1 "tensor_ros_sink: simple test case for raw data (uint8/BGRx)" 0 1
+
+gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=RGB,width=280,height=40,framerate=0/1 ! tee name=t ! queue ! tensor_converter silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.uint8.RGB.bag\" sync=true t. ! queue ! filesink location=\"simple.uint8.RGB.log\" sync=true" 1-2
+../test_utils.py simple.uint8.RGB.log simple.uint8.RGB.bag uint8 RGB 280 40
+testResult $? 1-2 "tensor_ros_sink: simple test case for raw data (uint8/RGB)" 0 1
+
+gstTest "-m -v --gst-plugin-path=${PATH_TO_PLUGIN} videotestsrc num-buffers=1 ! video/x-raw,format=GRAY8,width=280,height=40,framerate=0/1 ! tee name=t ! queue ! tensor_converter silent=TRUE ! tensor_ros_sink dummy=true enable-save-rosbag=true location=\"simple.uint8.GRAY8.bag\" sync=true t. ! queue ! filesink location=\"simple.uint8.GRAY8.log\" sync=true" 1-3
+../test_utils.py simple.uint8.GRAY8.log simple.uint8.GRAY8.bag uint8 GRAY8 280 40
+testResult $? 1-3 "tensor_ros_sink: simple test case for raw data (uint8/GRAY8)" 0 1
+
+report
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+
+##
+# Copyright (C) 2019 Samsung Electronics
+# License: LGPL-2.1
+#
+# @file test_utils.py
+# @brief Utility functions for test cases
+# @author Wook Song <wook16.song@samsung.com>
+
+import sys
+import os
+import struct
+import rosbag
+
+##
+# @brief Get the number of colors in a pixel from a given 'colorspace'
+# @param[in] colorspace 'RGB','BGR', 'RGBx', 'BGRx', 'xRGB', 'xBGR', 'RGBA', 'BGRA', 'ARGB', 'ABGR', 'GRAY8'
+# @return The number of colors or -1 if it fails
+
+
+def get_colors_per_px(colorspace):
+    if colorspace in ['RGB', 'BGR']:
+        colors_per_px = 3
+    elif colorspace in ['RGBx', 'BGRx', 'xRGB', 'xBGR', 'RGBA', 'BGRA', 'ARGB', 'ABGR']:
+        colors_per_px = 4
+    elif colorspace in ['GRAY8']:
+        colors_per_px = 1
+    else:
+        print('Unsupported colorspace {}'.format(colorspace))
+        return -1
+
+    return colors_per_px
+
+##
+# @brief Get a format string to pass to struct.unpack and the number of bytes per data
+# @param[in] data_type a string indicating the data type such as uint8, uint16...
+# @param[in] num_data the number of data
+# @param[in] byte_order 0 indicates 'little-endian' and the others indicate 'big-endian' (optional)
+# @return (string_format, num_bytes_per_data)
+
+
+def get_unpack_format_and_bytes_per_data(data_type, num_data, byte_order=0):
+
+    if byte_order == 0:
+        unpack_format = '<'
+    else:
+        unpack_format = '>'
+
+    unpack_format += str(num_data)
+
+    lower_data_type = data_type.lower()
+    if lower_data_type in ['uint8', 'int8']:
+        bytes_per_data = 1
+        if lower_data_type == 'uint8':
+            unpack_format += 'B'
+        else:
+            unpack_format += 'n'
+    elif lower_data_type in ['uint16', 'int16']:
+        bytes_per_data = 2
+        if lower_data_type == 'uint16':
+            unpack_format += 'H'
+        else:
+            unpack_format += 'h'
+    elif lower_data_type in ['uint32', 'int32', 'float32']:
+        bytes_per_data = 4
+        if lower_data_type == 'uint32':
+            unpack_format += 'I'
+        elif lower_data_type == 'int32':
+            unpack_format += 'i'
+        else:
+            unpack_format += 'f'
+    elif lower_data_type in ['uint64', 'int64', 'float64']:
+        bytes_per_data = 8
+        if lower_data_type == 'uint64':
+            unpack_format += 'Q'
+        elif lower_data_type == 'int32':
+            unpack_format += 'q'
+        else:
+            unpack_format += 'd'
+    else:
+        print('Unsupported data type {}'.format(data_type))
+        return (None, -1)
+
+    return (unpack_format, bytes_per_data)
+
+##
+# @brief Get a tuple of data stream in a tensor from a raw data file
+# @param[in] data_type a string indicating the data type such as uint8, uint16...
+# @param[in] colorspace 'RGB','BGR', 'RGBx', 'BGRx', 'xRGB', 'xBGR', 'RGBA', 'BGRA', 'ARGB', 'ABGR', 'GRAY8'
+# @param[in] width the width of the image
+# @param[in] height the height of the image
+# @param[in] filename a name of file that contains raw data of the image
+# @param[in] byte_order 0 indicates 'little-endian' and the others indicate 'big-endian' (optional)
+# @return a tuple of data stream in a tensor or None (if it fails)
+
+
+def get_tensor_stream_from_raw(data_type, colorspace, width, height, filename, byte_order=0):
+    try:
+        file_raw = open(filename, 'rb')
+    except IOError:
+        print('Failed to open the raw data file: {}'.format(filename))
+        return None
+    byte_stream = file_raw.read()
+    file_raw.close()
+
+    colors_per_px = get_colors_per_px(colorspace)
+    if colors_per_px is None:
+        return None
+    num_data = colors_per_px * width * height
+    unpack_format, bytes_per_data = get_unpack_format_and_bytes_per_data(
+        data_type, num_data)
+    if unpack_format is None and bytes_per_data == -1:
+        return None
+
+    size = bytes_per_data * num_data
+    if size != os.path.getsize(filename):
+        print('Failed to verify the raw data file: {}'.format(filename))
+        return None
+
+    data_stream = struct.unpack_from(unpack_format, byte_stream)
+
+    return data_stream
+
+##
+# @brief Get a tuple of data stream in a tensor from a rosbag file
+# @param[in] filename a name of file that contains raw data of the image
+# @param[in] byte_order 0 indicates 'little-endian' and the others indicate 'big-endian' (optional)
+# @return a tuple of data stream in a tensor or None (if it fails)
+
+
+def get_tensor_stream_from_bag(filename, byte_order=0):
+
+    MSG_FORMAT_OPEN_ERR = 'Failed to open the rosbag file: {}: '.format(
+        filename)
+    IDX_MSG_IN_TUPLE = 1
+
+    try:
+        bag = rosbag.Bag(filename)
+    except IOError:
+        print(MSG_FORMAT_OPEN_ERR + 'the file does not exist')
+        return None
+    except rosbag.bag.ROSBagException:
+        print(MSG_FORMAT_OPEN_ERR + 'the file is not a rosbag file')
+        return None
+    except rosbag.bag.ROSBagFormatException:
+        print(MSG_FORMAT_OPEN_ERR + 'the file has crashed')
+        return None
+
+    # Verfication procedure:
+    # This function is only for the case that the bag file has a tensor in a single msg
+    #   1. check that the number of msg is 1
+    #   2. check that the number of tensors is 1
+    #   3. check that the number of dimensions in a tensor is 4
+    #   4. check that data types of all the dimensions are same
+    num_msg = bag.get_message_count()
+    if num_msg != 1:
+        bag.close()
+        return None
+
+    gen_tuple = bag.read_messages()
+    msg = next(gen_tuple)[IDX_MSG_IN_TUPLE]
+    if len(msg.tensors) != 1:
+        bag.close()
+        return None
+
+    bag.close()
+    if len(msg.tensors[0].layout.dim) != 4:
+        return None
+
+    data_type = msg.tensors[0].layout.dim[0].label
+    if msg.tensors[0].layout.dim[1].label != data_type or \
+       msg.tensors[0].layout.dim[2].label != data_type or \
+       msg.tensors[0].layout.dim[3].label != data_type:
+        return None
+    num_data = msg.tensors[0].layout.dim[3].size * \
+        msg.tensors[0].layout.dim[2].size * \
+        msg.tensors[0].layout.dim[1].size
+
+    unpack_format, bytes_per_data = get_unpack_format_and_bytes_per_data(
+        data_type, num_data)
+    if unpack_format is None and bytes_per_data == -1:
+        return None
+
+    byte_stream = msg.tensors[0].data
+    if len(byte_stream) != num_data * bytes_per_data:
+        return None
+
+    data_stream = struct.unpack_from(unpack_format, byte_stream)
+
+    return data_stream
+
+
+if len(sys.argv) != 7:
+    exit(1)
+
+filename_raw = sys.argv[1]
+filename_rosbag = sys.argv[2]
+data_type = sys.argv[3]
+colorspace = sys.argv[4]
+width = int(sys.argv[5])
+height = int(sys.argv[6])
+
+data_stream_raw = get_tensor_stream_from_raw(
+    data_type, colorspace, width, height, filename_raw)
+if data_stream_raw is None or len(data_stream_raw) == 0:
+    exit(1)
+
+data_stream_bag = get_tensor_stream_from_bag(filename_rosbag)
+if data_stream_bag is None or len(data_stream_bag) == 0:
+    exit(1)
+if data_stream_raw != data_stream_bag:
+    exit(1)
+
+exit(0)


### PR DESCRIPTION
Related epic: https://github.com/nnsuite/nnstreamer/issues/1059
See also: https://github.com/nnsuite/nnstreamer/issues/1121

This PR mainly concerns adding a set of utilities and test cases for rosbag-based pipeline test.

### Details ###
- [Test/Common] Add a python script for rosbag-based tests
  - ~~In the current version, comparing a raw data file containing video/x-raw with a rosbag file corresponding to the raw file is only supported. (it will be extended.)~~
  - Comparing a raw data file containing video/x-raw or audio/x-raw with a rosbag file corresponding to the raw file is supported now.
- 1) [Test/Sink] Add rosbag-based pipeline test cases
- 2) [Test/Sink] Add test cases covering audio format 
  - Raw data files created by dumping a video/x-raw frame (RGB, BGRx, and GRAY8) and 8000 audio/x-raw frames (S16LE, F32LE, and F64LE) using filesink are compared with rosbag files corresponding those raw data files.

### Changes in this PR ###
- [V2] Update test_utils.py to support audio/x-raw format
- [V2] Add est cases covering audio format 

### Test Results ###
```bash
./nnstreamer-ros/tests  (add-unittest-sink) $ ssat

==================================================

==================================================
    Test Group rosbag-based pipeline test Starts.
[PASSED] 1-1:gst-launch of case 1-1
[PASSED] 1-1:tensor_ros_sink: simple test case using raw data (video/BGRx/uint8)
[PASSED] 1-2:gst-launch of case 1-2
[PASSED] 1-2:tensor_ros_sink: simple test case using raw data (video/RGB/uint8)
[PASSED] 1-3:gst-launch of case 1-3
[PASSED] 1-3:tensor_ros_sink: simple test case using raw data (video/GRAY8/uint8)
[PASSED] 2-1:gst-launch of case 2-1
[PASSED] 2-1:tensor_ros_sink: simple test case using raw data (audio/mono/s16le/8k)
[PASSED] 2-2:gst-launch of case 2-2
[PASSED] 2-2:tensor_ros_sink: simple test case using raw data (audio/stereo/s16le/8k)
[PASSED] 2-3:gst-launch of case 2-3
[PASSED] 2-3:tensor_ros_sink: simple test case using raw data (audio/mono/f32le/8k)
[PASSED] 2-4:gst-launch of case 2-4
[PASSED] 2-4:tensor_ros_sink: simple test case using raw data (audio/stereo/f32le/8k)
[PASSED] 2-5:gst-launch of case 2-5
[PASSED] 2-5:tensor_ros_sink: simple test case using raw data (audio/mono/f64le/8k)
[PASSED] 2-6:gst-launch of case 2-6
[PASSED] 2-6:tensor_ros_sink: simple test case using raw data (audio/stereo/f64le/8k)
==================================================
[PASSED] Test Group rosbag-based pipeline test Passed

==================================================

[PASSED] tensor_ros_sink (18 passed among 18 cases)
==================================================
[PASSED] All Test Groups (1) Passed!
         TC Passed: 18 / Failed: 0
```

Signed-off-by: Wook Song <wook16.song@samsung.com>