### PR TITLE
[Dist/Tizen] Add libtensor_ros_src.so into rpm package

### DIFF
--- a/packaging/nnstreamer-ros.spec
+++ b/packaging/nnstreamer-ros.spec
@@ -64,6 +64,7 @@ popd
 %manifest nnstreamer-ros.manifest
 %license LICENSE
 %{_libdir}/gstreamer-1.0/libtensor_ros_sink.so
+%{_libdir}/gstreamer-1.0/libtensor_ros_src.so
 %{__ros_install_path}/lib/libnns_ros_bridge.so
 %{__ros_install_path}/lib/python2.7/site-packages/nns_ros_bridge/*
 %{__ros_install_path}/share/nns_ros_bridge/cmake/*


### PR DESCRIPTION
This patch newly adds the libtensor_ros_src.so into rpm package to
resolve unpackaged issue.

* Related issue: #17 

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>