### PR TITLE
[Src] Remove input property from RosSrc

### DIFF
--- a/gst/tensor_ros_src/tensor_ros_src.h
+++ b/gst/tensor_ros_src/tensor_ros_src.h
@@ -58,9 +58,8 @@ struct _GstTensorRosSrc
   GThread *thread;        /** ros subscribe thread */
 
   gchar *topic_name;      /** ROS topic name to subscribe */
-  gchar *input_dims;      /** input dimemsion of ROS message */
-  guint count;            /** total item count of ROS message */
   tensor_type datatype;   /** Primitive datatype of ROS topic */
+  gsize payload_size;     /** Actual payload size of ROS message */
   gulong freq_rate;       /** frequency rate to check */
 
   GAsyncQueue *queue;     /** data queue */


### PR DESCRIPTION
Since Ros message contains its dimension information, `input` property
of RosSrc is not necessary. This patch removes the input property from
RosSrc and adds some assertion code to check its proper operations.

### Self evaluation:
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

### Related ussie
* https://github.com/nnsuite/nnstreamer/issues/870

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>