### PR TITLE
[Common] Unify common shared objects into one

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -130,8 +130,8 @@ catkin_package(
   DEPENDS ${PKGS_COMMON}
 )
 
-SET(CXX_SRC_FILES_NNS_ROS_BRIDGE
- ./node/nns_ros_bridge.cc
+SET(CXX_SRC_FILES_NNS_ROS_PUBLISHER
+ ./node/nns_ros_publisher.cc
 )
 
 SET(CXX_SRC_FILES_NNS_ROS_SRC
@@ -161,10 +161,8 @@ INCLUDE_DIRECTORIES(
 ## With catkin_make all packages are built within a single CMake context
 ## The recommended prefix ensures that target names across packages don't collide
 
-ADD_LIBRARY(nns_ros_bridge ${CXX_SRC_FILES_NNS_ROS_BRIDGE})
+ADD_LIBRARY(${PROJECT_NAME} ${CXX_SRC_FILES_NNS_ROS_PUBLISHER} ${CXX_SRC_FILES_NNS_ROS_SRC})
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-ADD_LIBRARY(nns_ros_subscriber ${CXX_SRC_FILES_NNS_ROS_SRC})
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -177,12 +175,7 @@ ADD_LIBRARY(nns_ros_subscriber ${CXX_SRC_FILES_NNS_ROS_SRC})
 # add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
-TARGET_LINK_LIBRARIES(nns_ros_bridge
-  ${catkin_LIBRARIES}
-  ${PKGS_COMMON_LIBRARIES}
-)
-
-TARGET_LINK_LIBRARIES(nns_ros_subscriber
+TARGET_LINK_LIBRARIES(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${PKGS_COMMON_LIBRARIES}
 )
@@ -235,7 +228,7 @@ TARGET_LINK_LIBRARIES(nns_ros_subscriber
 ## Add folders to be run by python nosetests
 # catkin_add_nosetests(test)
 
-INSTALL(TARGETS nns_ros_bridge
+INSTALL(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION ${ROS_INSTALL_BIN_DIR}
   LIBRARY DESTINATION ${ROS_INSTALL_LIB_DIR}
   ARCHIVE DESTINATION ${ROS_INSTALL_LIB_DIR}

--- a/common/include/nns_ros_publisher.h
+++ b/common/include/nns_ros_publisher.h
@@ -13,18 +13,18 @@
  *
  */
 /**
- * @file   nns_ros_bridge.h
+ * @file   nns_ros_pubisher.h
  * @author Wook Song <wook16.song@samsung.com>
  * @date   11/19/2018
- * @brief  A bridge for ROS support within NNStreamer
+ * @brief  A helper class to support publishing ROS topic within NNStreamer
  *
  * This class bridges between the NNStreamer (C) and ROS frameworks (ROSCPP/C++).
  *
  * @bug     No known bugs.
  */
 
-#ifndef _NNS_ROS_BRIDGE_H_
-#define _NNS_ROS_BRIDGE_H_
+#ifndef _NNS_ROS_PUBLISHER_H_
+#define _NNS_ROS_PUBLISHER_H_
 #include <glib-2.0/glib.h>
 #include <nnstreamer/tensor_typedef.h>
 #include <nnstreamer/nnstreamer_plugin_api.h>
@@ -38,18 +38,18 @@ typedef enum _err_code {
   FAILED_TO_CONNECT_ROSCORE,
 } err_code;
 
-class NnsRosBridge
+class NnsRosPublisher
 {
 public:
-  NnsRosBridge (const char *node_name, const char *topic_name,
+  NnsRosPublisher (const char *node_name, const char *topic_name,
       gboolean is_dummy_roscore);
-  ~NnsRosBridge ();
+  ~NnsRosPublisher ();
   gboolean publish (const guint num_tensors,
       const GstTensorMemory *tensors_mem, rosbag::Bag *bag);
   gboolean setPubTopicInfo (const GstTensorsConfig *conf);
   const gchar *getPubTopicName ();
 private:
-  NnsRosBridge ();
+  NnsRosPublisher ();
 
   // Variables for ROS configuration
   ros::NodeHandle *nh_parent;
@@ -68,17 +68,17 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-void *nns_ros_bridge_init (const char *node_name, const char *topic_name,
+void *nns_ros_publisher_init (const char *node_name, const char *topic_name,
     gboolean is_dummy_roscore);
-void nns_ros_bridge_finalize (void *instance);
-gboolean nns_ros_bridge_publish (void *instance, const guint num_tensors,
+void nns_ros_publisher_finalize (void *instance);
+gboolean nns_ros_publisher_publish (void *instance, const guint num_tensors,
     const GstTensorMemory *tensors_mem, void *bag);
-gboolean nns_ros_bridge_set_pub_topic (void *instance,
+gboolean nns_ros_publisher_set_pub_topic (void *instance,
     const GstTensorsConfig *conf);
-const gchar *nns_ros_bridge_get_pub_topic_name (void *instance);
-void *nns_ros_bridge_open_writable_bag (void *instance, const char *name);
-void nns_ros_bridge_close_bag (void *bag);
+const gchar *nns_ros_publisher_get_pub_topic_name (void *instance);
+void *nns_ros_publisher_open_writable_bag (void *instance, const char *name);
+void nns_ros_publisher_close_bag (void *bag);
 #ifdef __cplusplus
 };
 #endif /* __cplusplus */
-#endif /* _NNS_ROS_BRIDGE_H_ */
+#endif /* _NNS_ROS_PUBLISHER_H_ */

--- a/gst/tensor_ros_sink/tensor_ros_sink.c
+++ b/gst/tensor_ros_sink/tensor_ros_sink.c
@@ -32,7 +32,7 @@
 #include <config.h>
 #endif
 
-#include <nns_ros_bridge.h>
+#include <nns_ros_publisher.h>
 #include <nnstreamer/tensor_typedef.h>
 #include <nnstreamer/nnstreamer_plugin_api.h>
 
@@ -479,8 +479,8 @@ gst_tensor_ros_sink_finalize (GObject *object)
 
   g_mutex_clear (&self->mutex);
   g_free (self->location);
-  nns_ros_bridge_close_bag (self->rosbag_to_save);
-  nns_ros_bridge_finalize (self->nns_ros_bind_instance);
+  nns_ros_publisher_close_bag (self->rosbag_to_save);
+  nns_ros_publisher_finalize (self->nns_ros_bind_instance);
 
   self->location = NULL;
   self->rosbag_to_save = NULL;
@@ -506,14 +506,14 @@ gst_tensor_ros_sink_start (GstBaseSink *sink)
   pid = getpid ();
   str_pid = g_strdup_printf (format_node_name_pid, pid);
 
-  self->nns_ros_bind_instance = nns_ros_bridge_init (str_pid,
+  self->nns_ros_bind_instance = nns_ros_publisher_init (str_pid,
       GST_ELEMENT_NAME (GST_ELEMENT (sink)), self->dummy);
   g_free (str_pid);
 
   g_return_val_if_fail (self->nns_ros_bind_instance != NULL, FALSE);
   if (self->save_rosbag) {
     self->rosbag_to_save =
-        nns_ros_bridge_open_writable_bag (self->nns_ros_bind_instance,
+        nns_ros_publisher_open_writable_bag (self->nns_ros_bind_instance,
         self->location);
     g_return_val_if_fail (self->rosbag_to_save != NULL, FALSE);
   }
@@ -694,7 +694,7 @@ gst_tensor_ros_sink_set_caps (GstBaseSink *sink, GstCaps *caps)
   }
 
   self->in_config = in_conf;
-  nns_ros_bridge_set_pub_topic (self->nns_ros_bind_instance,
+  nns_ros_publisher_set_pub_topic (self->nns_ros_bind_instance,
     &self->in_config);
 
   return TRUE;
@@ -762,7 +762,7 @@ gst_tensor_ros_sink_render_buffer (GstTensorRosSink *self, GstBuffer *inbuf)
     in_tensors[i].type = self->in_config.info.info[i].type;
   }
 
-  if ((!nns_ros_bridge_publish (self->nns_ros_bind_instance, num_in_tensors,
+  if ((!nns_ros_publisher_publish (self->nns_ros_bind_instance, num_in_tensors,
       in_tensors, self->rosbag_to_save))) {
     for (i = 0; i < num_in_tensors; ++i) {
       gst_memory_unmap (in_mem[i], &in_info[i]);

--- a/gst/tensor_ros_src/CMakeLists.txt
+++ b/gst/tensor_ros_src/CMakeLists.txt
@@ -9,13 +9,13 @@ PKG_CHECK_MODULES(PKGS REQUIRED ${ROSSRC_PKG_MODULES})
 LINK_DIRECTORIES(${PKGS_LIBRARY_DIRS})
 
 ADD_LIBRARY(tensor_ros_src tensor_ros_src.cc)
-ADD_DEPENDENCIES(tensor_ros_src nns_ros_subscriber)
+ADD_DEPENDENCIES(tensor_ros_src nns_ros_bridge)
 TARGET_INCLUDE_DIRECTORIES(tensor_ros_src PRIVATE
   ${PKGS_INCLUDE_DIRS}
 )
 
 TARGET_LINK_LIBRARIES(tensor_ros_src
-  nns_ros_subscriber
+  nns_ros_bridge
   ${PKGS_COMMON_LIBRARIES}
   ${PKGS_LIBRARIES}
 )


### PR DESCRIPTION
This patch unifies separated shared objects for publisher and subscriberinto one shared object named nns_ros_bridge.so.

Signed-off-by: Wook Song <wook16.song@samsung.com>