### PR TITLE
[Test/Src] Add basic unit test cases for RosSrc

### DIFF
--- a/gst/tensor_ros_src/tensor_ros_src.cc
+++ b/gst/tensor_ros_src/tensor_ros_src.cc
@@ -280,7 +280,7 @@ gst_tensor_ros_src_class_init (GstTensorRosSrcClass * klass)
       (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 
   g_object_class_install_property (gobject_class, PROP_FREQ_RATE,
-    g_param_spec_ulong ("freqrate", "Frequency_Rate",
+    g_param_spec_uint64 ("freqrate", "Frequency_Rate",
       "Frequency rate for checking Ros Topic(Hz, Default: 1Hz)",
       1, G_USEC_PER_SEC, 1, G_PARAM_READWRITE));
 
@@ -387,7 +387,7 @@ gst_tensor_ros_src_set_property (GObject * object, guint prop_id,
       break;
 
     case PROP_FREQ_RATE:
-      rossrc->freq_rate = G_USEC_PER_SEC / g_value_get_ulong (value);
+      rossrc->freq_rate = static_cast<gulong>(G_USEC_PER_SEC / g_value_get_uint64 (value));
       GST_DEBUG_OBJECT (rossrc, "Freq Hz: %lu\n", G_USEC_PER_SEC / rossrc->freq_rate);
       break;
 
@@ -421,7 +421,7 @@ gst_tensor_ros_src_get_property (GObject * object, guint prop_id,
       break;
 
     case PROP_FREQ_RATE:
-      g_value_set_ulong (value, G_USEC_PER_SEC / rossrc->freq_rate);
+      g_value_set_uint64 (value, G_USEC_PER_SEC / rossrc->freq_rate);
       break;
 
     case PROP_DATATYPE:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 ADD_SUBDIRECTORY(tensor_ros_sink)
+ADD_SUBDIRECTORY(tensor_ros_src)

--- a/tests/tensor_ros_src/CMakeLists.txt
+++ b/tests/tensor_ros_src/CMakeLists.txt
@@ -1,0 +1,37 @@
+SET(PKG_MODULES
+  gstreamer-base-1.0
+  gstreamer-check-1.0
+  gstreamer-plugins-base-1.0
+)
+
+FIND_LIBRARY(GTEST_LIB gtest)
+IF(GTEST_LIB OR TIZEN)
+  # Use GTEST shared lib (Tizen supplied gtest as shared lib)
+  SET(GTEST_LINK_LIBS gtest pthread)
+  SET(GTEST_SRC "")
+  SET(GTEST_INC "")
+ELSE(GTEST_LIB OR TIZEN)
+  IF(NOT EXISTS /usr/src/gtest/src/gtest-all.cc)
+    MESSAGE(FATAL_ERROR "You need to install libgtest-dev or (supplied with GTEST_LIB) libgtest.so.")
+  ENDIF (NOT EXISTS /usr/src/gtest/src/gtest-all.cc)
+  SET(GTEST_LINK_LIBS pthread)
+  SET(GTEST_SRC /usr/src/gtest/src/gtest-all.cc)
+  SET(GTEST_INC /usr/src/gtest)
+ENDIF(GTEST_LIB OR TIZEN)
+
+PKG_CHECK_MODULES(PKGS_TEST REQUIRED ${PKG_MODULES})
+ADD_EXECUTABLE(unittest_tensor_ros_src unittest_tensor_ros_src.cpp ${GTEST_SRC})
+TARGET_INCLUDE_DIRECTORIES(unittest_tensor_ros_src PRIVATE
+  ${PKGS_COMMON_INCLUDE_DIRS}
+  ${PKGS_TEST_INCLUDE_DIRS}
+  ${GTEST_INC}
+)
+
+TARGET_LINK_LIBRARIES(unittest_tensor_ros_src
+  ${PKGS_COMMON_LIBRARIES}
+  ${PKGS_TEST_LIBRARIES}
+  ${GTEST_LINK_LIBS}
+)
+
+ADD_TEST(NAME unittest_tensor_ros_src.properties
+  COMMAND unittest_tensor_ros_src --gtest_filter=test_tensor_ros_sink.properties)

--- a/tests/tensor_ros_src/unittest_tensor_ros_src.cpp
+++ b/tests/tensor_ros_src/unittest_tensor_ros_src.cpp
@@ -1,0 +1,89 @@
+/**
+ * @file	unittest_ros_src.cpp
+ * @date	18 March 2019
+ * @brief	Unit test for tensor_ros_src
+ * @see		https://github.com/nnsuite/nnstreamer-ros
+ * @author	Sangjung Woo <sangjung.woo@samsung.com>
+ * @bug		No known bugs.
+ */
+#include <gtest/gtest.h>
+#include <gst/gst.h>
+#include <gst/check/gstharness.h>
+
+#define LAUNCHLINE_ROSSRC "tensor_ros_src"
+#define TARGET_ELEMENT_NAME "tensor_ros_src"
+
+const guint64 DEFAULT_FREQRATE = 1;
+const gchar *DATATYPES[] = { "int32", "uint32",
+                            "int8", "uint8",
+                            "int16", "uint16",
+                            "int64", "uint64",
+                            "float32" , "float64"};
+
+TEST (test_tensor_ros_src, properties)
+{
+  GstHarness *hrnss = NULL;
+  GstElement *rossrc = NULL;
+  gchar *name;
+  const gchar default_name[] = "tensorrossrc0";
+  const gchar *topic_name = "test_topic";
+  gchar *ret_topic_name;
+  guint64 freqrate;
+  guint64 ret_freqrate;
+  gchar *ret_datatype;
+
+  /* setup */
+  hrnss = gst_harness_new_empty ();
+  ASSERT_TRUE (hrnss != NULL);
+  gst_harness_add_parse (hrnss, LAUNCHLINE_ROSSRC);
+  rossrc = gst_harness_find_element (hrnss, TARGET_ELEMENT_NAME);
+  ASSERT_TRUE (rossrc != NULL);
+
+  /* check the default name */
+  name = gst_element_get_name (rossrc);
+  ASSERT_TRUE (name != NULL);
+  EXPECT_STREQ (default_name, name);
+  g_free (name);
+
+  /* topic name test */
+  g_object_set (rossrc, "topic", topic_name, NULL);
+  g_object_get (rossrc, "topic", &ret_topic_name, NULL);
+  EXPECT_STREQ (topic_name, ret_topic_name);
+  g_free (ret_topic_name);
+
+  /* freqrate test */
+  g_object_get (rossrc, "freqrate", &ret_freqrate, NULL);
+  EXPECT_EQ (ret_freqrate, DEFAULT_FREQRATE);
+
+  freqrate = 10;
+  g_object_set (rossrc, "freqrate", freqrate, NULL);
+  g_object_get (rossrc, "freqrate", &ret_freqrate, NULL);
+  EXPECT_EQ (ret_freqrate, freqrate);
+
+  /* datatype test */
+  g_object_get (rossrc, "datatype", &ret_datatype, NULL);
+  EXPECT_STREQ (ret_datatype, DATATYPES[0]);
+
+  unsigned int size = sizeof(DATATYPES) / sizeof(DATATYPES[0]);
+  for (unsigned int i = 0; i < size; ++i) {
+    g_object_set (rossrc, "datatype", DATATYPES[i], NULL);
+    g_object_get (rossrc, "datatype", &ret_datatype, NULL);
+    EXPECT_STREQ (ret_datatype, DATATYPES[i]);
+  }
+
+  /* teardown */
+  gst_harness_teardown (hrnss);
+}
+
+/**
+ * @brief Main function for unit test.
+ */
+int
+main (int argc, char **argv)
+{
+  testing::InitGoogleTest (&argc, argv);
+
+  gst_init (&argc, &argv);
+
+  return RUN_ALL_TESTS ();
+}


### PR DESCRIPTION
This PR newly adds the basic unit test cases for RosSrc. Detailed patches is as below.
* [Src] Use uint64 instead of ulong for freqrate property
* [Test/Src] Add unit test cases for setting/getting properties

### Self evaluation:
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped


### Expected results
```bash
$ make test
Running tests...
Test project /home/again4you/nnstreamer_work/ros_node_work/unit_test/nnstreamer-ros/build
      Start  1: unittest_tensor_ros_sink.properties
 1/12 Test  #1: unittest_tensor_ros_sink.properties .................   Passed    0.04 sec
      Start  2: unittest_tensor_ros_sink.signal_new_data_uint8_t
 2/12 Test  #2: unittest_tensor_ros_sink.signal_new_data_uint8_t ....   Passed    0.28 sec
...
      Start 12: unittest_tensor_ros_src.properties
12/12 Test #12: unittest_tensor_ros_src.properties ..................   Passed    0.04 sec

100% tests passed, 0 tests failed out of 12

Total Test time (real) =   5.93 sec
```

### Related issue
* https://github.com/nnsuite/nnstreamer/issues/1059

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>