### PR TITLE
[Src] Provide the downstream with output tensor information

### DIFF
--- a/gst/tensor_ros_src/tensor_ros_listener.hpp
+++ b/gst/tensor_ros_src/tensor_ros_listener.hpp
@@ -61,7 +61,20 @@ class RosListener {
         g_assert (payload_size != 0); \
         \
         if (!this->is_initialized) { \
+          gint i; \
           this->rossrc->payload_size = payload_size; \
+          \
+          /* Set TensorConfig based on Ros message */ \
+          for (i = 0; i < NNS_TENSOR_RANK_LIMIT; ++i) \
+            this->rossrc->config.info.dimension[i] = 1; \
+          \
+          for (i = 0; i < NNS_TENSOR_RANK_LIMIT; ++i) { \
+            if (msg.layout.dim[i].size == 1) \
+            break; \
+          this->rossrc->config.info.dimension[i] = msg.layout.dim[i].size; \
+          } \
+          this->rossrc->config.info.type =  this->rossrc->datatype; \
+          this->rossrc->configured = true; \
           this->is_initialized = true; \
         } \
         /* After NNstreamer pipeline is setup and playing, \

--- a/gst/tensor_ros_src/tensor_ros_src.h
+++ b/gst/tensor_ros_src/tensor_ros_src.h
@@ -53,7 +53,8 @@ struct _GstTensorRosSrc
 {
   GstPushSrc parent;
 
-  GstCaps *caps;
+  GstTensorConfig config; /** Output Tensor configuration */
+  gboolean configured;    /** is configured based on Ros message */
   gboolean silent;
   GThread *thread;        /** ros subscribe thread */
 


### PR DESCRIPTION
In order to provide the downstream with output tensor information, which
is based on Ros Message, this patch newly adds and modifies some
handlers related with Caps. Detailed items are as below.

* Get the tensor dimensions from Ros message.
* Add caps handler for providing the downstream with output tensor
  information.
* Use start & stop handler instead of change_state handler.
* Fix the bug related with caps negotiation

### Self evaluation:
1. Build test: [*]Passed [ ]Failed []Skipped
2. Run test: [*]Passed [ ]Failed []Skipped

### Related Issue
* https://github.com/nnsuite/nnstreamer/issues/870

### How to test
1. Run `roscore` first
2. Run `pyros_publisher.py` as below for testing
```bash
$ ./pyros_publisher.py -n test_node -t test_topic -d int32 -e 5:2:2:1 -r 4
```
3. Run `gst-launch` command as below. This command subscribes ros message and re-publish it as tensor format using `tensor_ros_sink`
```bash
GST_DEBUG=tensor_ros_*:5 gst-launch-1.0 \
tensor_ros_src topic=test_topic freqrate=1 datatype=int32 silent=false ! \
tensor_ros_sink silent=false
```
4. Check the published topic as below.
```bash
$ rostopic list
/rosout
/rosout_agg
/tensor_ros_sink/PID_31919/tensorrossink0
/test_topic
```

Signed-off-by: Sangjung Woo <sangjung.woo@samsung.com>