### PR TITLE
[README] Add a badge for displaying code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
+
 [![GitHub license](https://img.shields.io/github/license/nnsuite/nnstreamer-ros.svg?style=plastic)](./LICENSE)
 
 # NNStreamer-ROS
 
-NNStreamer-ROS is a set of NNStreamer extension plugins for [ROS Kinetic Kame](http://wiki.ros.org/kinetic) support.
+[![Code Coverage](http://nnsuite.mooo.com/nnstreamer-ros/ci/badge/codecoverage.svg)](http://nnsuite.mooo.com/nnstreamer-ros/ci/gcov_html/index.html)
 
 ## Official Releases
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-
-[![GitHub license](https://img.shields.io/github/license/nnsuite/nnstreamer-ros.svg?style=plastic)](./LICENSE)
-
-# NNStreamer-ROS
+# NNStreamer-ROS [![GitHub license](https://badgen.net/badge/license/LGPL-2.1/blue)](./LICENSE)
 
 [![Code Coverage](http://nnsuite.mooo.com/nnstreamer-ros/ci/badge/codecoverage.svg)](http://nnsuite.mooo.com/nnstreamer-ros/ci/gcov_html/index.html)
 


### PR DESCRIPTION
This PR adds a badge which displays code coverage status to README. The existing badge for the license is also changed to the one has a similar look with the code coverage badge.

Signed-off-by: Wook Song <wook16.song@samsung.com>
