### PR TITLE
[Test/Src] bugfix: Enable test cases for setting/getting properties

### DIFF
--- a/packaging/nnstreamer-ros.spec
+++ b/packaging/nnstreamer-ros.spec
@@ -63,7 +63,7 @@ CFLAGS="${CFLAGS} -fprofile-arcs -ftest-coverage"
 
 %check
 pushd build
-export GST_PLUGIN_PATH=$(pwd)/gst/tensor_ros_sink
+export GST_PLUGIN_PATH=$(pwd)/gst/tensor_ros_sink:$(pwd)/gst/tensor_ros_src
 make test ARGS=-V
 popd
 pushd tests

--- a/tests/tensor_ros_src/CMakeLists.txt
+++ b/tests/tensor_ros_src/CMakeLists.txt
@@ -34,4 +34,4 @@ TARGET_LINK_LIBRARIES(unittest_tensor_ros_src
 )
 
 ADD_TEST(NAME unittest_tensor_ros_src.properties
-  COMMAND unittest_tensor_ros_src --gtest_filter=test_tensor_ros_sink.properties)
+  COMMAND unittest_tensor_ros_src --gtest_filter=test_tensor_ros_src.properties)


### PR DESCRIPTION
In order to properly enable unit test cases for tensor_ros_src, this patch fixes typo in the cmake script for tensor_ros_src and adds tensor_ros_src path to the GST_PLUGIN_PATH in the rpm spec file.

Signed-off-by: Wook Song <wook16.song@samsung.com>