### PR TITLE
[Common/Publisher] bugfix: Fix build errors 

### DIFF
--- a/common/node/nns_ros_publisher.cc
+++ b/common/node/nns_ros_publisher.cc
@@ -254,7 +254,7 @@ nns_ros_publisher_open_writable_bag (void * instance, const char *name)
   rosbag::Bag *bag;
   char *path_rosbag;
 
-  if (name == NULL || name == '\0') {
+  if (name == NULL || name[0] == '\0') {
     path_rosbag = g_strdup_printf ("%s.bag",
         nns_ros_publisher_get_pub_topic_name (instance));
   } else {

--- a/common/node/nns_ros_publisher.cc
+++ b/common/node/nns_ros_publisher.cc
@@ -263,7 +263,7 @@ nns_ros_publisher_open_writable_bag (void * instance, const char *name)
 
   try {
     bag = new rosbag::Bag(std::string (path_rosbag), rosbag::bagmode::Write);
-  } catch (rosbag::BagException e){
+  } catch (rosbag::BagException &e){
     bag = NULL;
   }
   g_free(path_rosbag);


### PR DESCRIPTION
This PR fixes the following build errors found while integrating nnstreamer-ros into meta-neural-network.

- error: ISO C++ forbids comparison between pointer and integer [-fpermissive]
- error: catching polymorphic type 'class rosbag::BagException' by value [-Werror=catch-value=]

Signed-off-by: Wook Song <wook16.song@samsung.com>