### PR TITLE
[NNStreamer/API] Follow changes in NNStreamer API @open sesame 09/24 16:00 

### DIFF
--- a/common/node/nns_ros_publisher.cc
+++ b/common/node/nns_ros_publisher.cc
@@ -110,7 +110,7 @@ gboolean NnsRosPublisher::setPubTopicInfo (const GstTensorsConfig *conf)
        * FIXME: Since the type of 'stride' of std_msgs::MultiArrayDimension is
        * unsigned int,conversion from size_t to unsigned int is requried.
        */
-      each_dim.label = tensor_element_typename[tensors_info->info[i].type];
+      each_dim.label = gst_tensor_get_type_string(tensors_info->info[i].type);
       each_dim.size =
           tensors_info->info[i].dimension[j];
       if (j != (NNS_TENSOR_RANK_LIMIT - 1)) {

--- a/gst/tensor_ros_src/tensor_ros_listener.hpp
+++ b/gst/tensor_ros_src/tensor_ros_listener.hpp
@@ -57,7 +57,7 @@ class RosListener {
     public: \
       DATATYPE##RosListener (GstTensorRosSrc *rossrc) : RosListener (rossrc) { } \
       void Callback(const std_msgs::DATATYPE##MultiArray msg) { \
-        gsize payload_size = msg.layout.dim[0].stride * tensor_element_size[rossrc->datatype]; \
+        gsize payload_size = msg.layout.dim[0].stride * gst_tensor_get_element_size (rossrc->datatype); \
         g_assert (payload_size != 0); \
         \
         if (!this->is_initialized) { \


### PR DESCRIPTION
Since NNStreamer has changes in API, several symbols used in this NNStreamer plugin are not valid anymore. To fix this issue, this patch updates such symbols to new ones.

Signed-off-by: Wook Song <wook16.song@samsung.com>