### PR TITLE
[Ros]change license to LGPL-2.1

### DIFF
--- a/common/include/nns_ros_publisher.h
+++ b/common/include/nns_ros_publisher.h
@@ -3,8 +3,8 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; 
+ * version 2.1 of the License.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/common/include/nns_ros_subscriber.h
+++ b/common/include/nns_ros_subscriber.h
@@ -3,8 +3,8 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; 
+ * version 2.1 of the License.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/common/node/nns_ros_publisher.cc
+++ b/common/node/nns_ros_publisher.cc
@@ -3,8 +3,8 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; 
+ * version 2.1 of the License.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/common/node/nns_ros_subscriber.cc
+++ b/common/node/nns_ros_subscriber.cc
@@ -3,8 +3,8 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; 
+ * version 2.1 of the License.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/gst/tensor_ros_sink/tensor_ros_sink.c
+++ b/gst/tensor_ros_sink/tensor_ros_sink.c
@@ -6,8 +6,8 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; 
+ * version 2.1 of the License.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/gst/tensor_ros_sink/tensor_ros_sink.h
+++ b/gst/tensor_ros_sink/tensor_ros_sink.h
@@ -6,8 +6,8 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; 
+ * version 2.1 of the License.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/gst/tensor_ros_src/tensor_ros_listener.hpp
+++ b/gst/tensor_ros_src/tensor_ros_listener.hpp
@@ -3,8 +3,8 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; 
+ * version 2.1 of the License.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/gst/tensor_ros_src/tensor_ros_src.cc
+++ b/gst/tensor_ros_src/tensor_ros_src.cc
@@ -6,8 +6,8 @@
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; 
+ * version 2.1 of the License.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/gst/tensor_ros_src/tensor_ros_src.h
+++ b/gst/tensor_ros_src/tensor_ros_src.h
@@ -6,8 +6,8 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
- * License as published by the Free Software Foundation; either
- * version 2 of the License, or (at your option) any later version.
+ * License as published by the Free Software Foundation; 
+ * version 2.1 of the License.
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
https://github.com/nnstreamer/nnstreamer/issues/2588
[Finding 8](https://lfscanning.org/reports/lfai/nnstreamer-2020-06-02-db85d4bf-ad70-4abf-80a6-d52dd1f6f3f1.html)
I changed license version 2 of the License to LGPL-2.1

nnstreamer-ros/common/include/nns_ros_publisher.h
nnstreamer-ros/common/include/nns_ros_subscriber.h
nnstreamer-ros/common/node/nns_ros_publisher.cc
nnstreamer-ros/common/node/nns_ros_subscriber.cc
nnstreamer-ros/gst/tensor_ros_sink/tensor_ros_sink.c
nnstreamer-ros/gst/tensor_ros_sink/tensor_ros_sink.h
nnstreamer-ros/gst/tensor_ros_src/tensor_ros_listener.hpp
nnstreamer-ros/gst/tensor_ros_src/tensor_ros_src.cc
nnstreamer-ros/gst/tensor_ros_src/tensor_ros_src.h

**Self evaluation:**
1. Build test: [ ]Passed [ ]Failed [*]Skipped
2. Run test: [ ]Passed [ ]Failed [* ]Skipped

Signed-off-by: HyesuAhn <linim@naver.com>