### PR TITLE
[GitHub] Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 # The lists of people and groups are for github.com
 
 # All members of nnstreamer-team are supposed to review each other
-*                                             @nnsuite/nnstreamer @myungjoo @jijoongmoon @again4you @jaeyun-jung @leemgs @wooksong @helloahn @kparichay
+* @nnstreamer/nnstreamer @myungjoo @jijoongmoon @again4you @jaeyun-jung @leemgs @wooksong @helloahn @kparichay @dongju-chae @gichan-jang @anyj0527 @zhoonit
 


### PR DESCRIPTION
This is a trivial modification to update the CODEOWNERS filte to include all the members in the NNStreamer team.

Signed-off-by: Wook Song <wook16.song@samsung.com>