### PR TITLE
[GitHub/Actions] Check code coverage via coverall only for push event

### DIFF
--- a/.github/workflows/tc_runners.yml
+++ b/.github/workflows/tc_runners.yml
@@ -101,6 +101,7 @@ jobs:
           lcov -t 'NNStreamer-ROS Unit Test Coverage' -o unittest.info -c -d ${{runner.workspace}}/build -b . --no-external
           lcov -r unittest.info "*/tests/*" "*rosidl_generator*/*" "*rosidl_typesupport*/*" "*.h" -o coverage/lcov.info
       - name: Coveralls Parallel
+        if: ${{ github.event_name == 'push' }}
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}
@@ -111,6 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coverall
+        if: ${{ github.event_name == 'push' }}
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This patch modifies the tc_runners workflow to check the code coverage via coverall only for the push event.

Signed-off-by: Wook Song <wook16.song@samsung.com>