### PR TITLE
[README.md] Use badges in Official Releases as links for packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 ## Official Releases
 |    |     Distro    | Tizen | Ubuntu |
 |:--:|      :--:     |     :--:    |   :--:  |
-|ROS1|Kinetic Kame|[![Tizen6.0](https://img.shields.io/badge/6.0-armv7l%20%7C%20aarch64%20%7C%20x86__64-blue)](http://download.tizen.org/live/devel%3A/Tizen%3A/6.0%3A/AI/Tizen_Unified_standard/)|[![Ubuntu16.04](https://img.shields.io/badge/16.04-x86__64-blue)]()|
-|    |Melodic Morenia|[![NotSupported](https://img.shields.io/badge/Not%20Supported-red)]()|[![Ubuntu18.04](https://img.shields.io/badge/18.04-x86__64-blue)]()|
-|    |Noetic Ninjemys|[![NotSupported](https://img.shields.io/badge/Not%20Supported-red)]()|[![Ubuntu18.04](https://img.shields.io/badge/18.04-x86__64-blue)]()|[![Ubuntu16.04](https://img.shields.io/badge/16.04-x86__64-blue)]()|
-|ROS2|Eloquent Elusor|[![NotSupported](https://img.shields.io/badge/Not%20Supported-red)]()|[![Ubuntu18.04](https://img.shields.io/badge/18.04-x86__64-blue)]()|
+|ROS1|Kinetic Kame|[![Tizen6.0](https://img.shields.io/badge/6.0-armv7l%20%7C%20aarch64%20%7C%20x86__64-blue)](http://download.tizen.org/live/devel%3A/Tizen%3A/6.0%3A/AI/Tizen_Unified_standard/)|[![Ubuntu16.04](https://img.shields.io/badge/16.04-x86__64-blue)](https://github.com/nnstreamer/nnstreamer-ros/releases/download/v0.1.1/nnstreamer-ros_0.1.1_202011260230_xenial_amd64.deb)|
+|    |Melodic Morenia|![NotSupported](https://img.shields.io/badge/Not%20Supported-red)|[![Ubuntu18.04](https://img.shields.io/badge/18.04-x86__64-blue)](https://github.com/nnstreamer/nnstreamer-ros/releases/download/v0.1.1/nnstreamer-ros_0.1.1_202011260233_bionic_amd64.deb)|
+|    |Noetic Ninjemys|![NotSupported](https://img.shields.io/badge/Not%20Supported-red)|![Ubuntu18.04](https://img.shields.io/badge/18.04-x86__64-blue)|
+|ROS2|Eloquent Elusor|![NotSupported](https://img.shields.io/badge/Not%20Supported-red)|[![Ubuntu18.04](https://img.shields.io/badge/18.04-x86__64-blue)](https://github.com/nnstreamer/nnstreamer-ros/releases/download/v0.1.1/nnstreamer-ros2_0.1.1_202011260233_bionic_amd64.deb)|
 
 ## Getting Started
 * For Ubuntu distributions, please refer [here](documents/getting-started-ubuntu.md).


### PR DESCRIPTION
This patch modifies README.md to use badges in Official Releases as download links for released packages.

Signed-off-by: Wook Song <wook16.song@samsung.com>