### PR TITLE
[ROS] Correct version string not matching with the release version

### DIFF
--- a/ros/package.xml
+++ b/ros/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>nns_ros_bridge</name>
-  <version>0.0.1</version>
+  <version>0.1.1</version>
   <description>A bridge for ROS support within NNStreamer</description>
   <maintainer email="wook16.song@samsung.com">Wook Song</maintainer>
   <author email="woo16.song@samsung.com">Wook Song</author>

--- a/ros2/package.xml
+++ b/ros2/package.xml
@@ -2,9 +2,9 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>nns_ros2_bridge</name>
-  <version>0.0.1</version>
+  <version>0.1.1</version>
   <description>A bridge for ROS2 support within NNStreamer</description>
-  <maintainer email="wook16.song@samsung.com">wook</maintainer>
+  <maintainer email="wook16.song@samsung.com">Wook Song</maintainer>
   <author>Wook Song</author>
   <license>LGPLv2.1</license>
 


### PR DESCRIPTION
This patch corrects the version strings not matching with the release version, i.e., 0.1.1.

Signed-off-by: Wook Song <wook16.song@samsung.com>